### PR TITLE
Added `getLabel` method to `Series`

### DIFF
--- a/etc/paramodel.api.md
+++ b/etc/paramodel.api.md
@@ -318,6 +318,8 @@ export class Series {
     // (undocumented)
     getFacetStats(key: string): FacetStats | null;
     // (undocumented)
+    getLabel(): string;
+    // (undocumented)
     readonly id: string;
     // (undocumented)
     readonly key: string;

--- a/lib/model/series.ts
+++ b/lib/model/series.ts
@@ -118,6 +118,14 @@ export class Series {
     }
     return ss.mean(this.datapoints.map((point) => point.facetValueAsNumber(key)!));
   }
+
+  @Memoize()
+  public getLabel(): string {
+    if (this.label) {
+      return this.label;
+    }
+    return this.key;
+  }
 }
 
 export class XYSeries extends Series {


### PR DESCRIPTION
Adds a `getLabel` method to `Series` which will return the series label if it exists, and the series key otherwise