### PR TITLE
Add useWorker option to Models

### DIFF
--- a/etc/paramodel.api.md
+++ b/etc/paramodel.api.md
@@ -189,7 +189,7 @@ export interface Intersection {
 
 // @public (undocumented)
 export class Model {
-    constructor(series: Series[], manifest: Manifest, seriesAnalyzerConstructor?: SeriesAnalyzerConstructor | undefined, pairAnalyzerConstructor?: PairAnalyzerConstructor);
+    constructor(series: Series[], manifest: Manifest, seriesAnalyzerConstructor?: SeriesAnalyzerConstructor | undefined, pairAnalyzerConstructor?: PairAnalyzerConstructor, _useWorker?: boolean);
     // (undocumented)
     [i: number]: Series;
     // (undocumented)
@@ -273,16 +273,18 @@ export class Model {
     // (undocumented)
     readonly type: ChartType;
     // (undocumented)
+    protected _useWorker: boolean;
+    // (undocumented)
     protected _verticalAxisFacetKey: string | null;
     // (undocumented)
     readonly xy: boolean;
 }
 
 // @public (undocumented)
-export function modelFromExternalData(data: AllSeriesData, manifest: Manifest, seriesAnalyzerConstructor?: SeriesAnalyzerConstructor, pairAnalyzerConstructor?: PairAnalyzerConstructor): Model;
+export function modelFromExternalData(data: AllSeriesData, manifest: Manifest, seriesAnalyzerConstructor?: SeriesAnalyzerConstructor, pairAnalyzerConstructor?: PairAnalyzerConstructor, useWorker?: boolean): Model;
 
 // @public (undocumented)
-export function modelFromInlineData(manifest: Manifest, seriesAnalyzerConstructor?: SeriesAnalyzerConstructor, pairAnalyzerConstructor?: PairAnalyzerConstructor): Model;
+export function modelFromInlineData(manifest: Manifest, seriesAnalyzerConstructor?: SeriesAnalyzerConstructor, pairAnalyzerConstructor?: PairAnalyzerConstructor, useWorker?: boolean): Model;
 
 // @public (undocumented)
 export type PairAnalyzerConstructor = new (seriesArray: Line[], screenCoordSysSize: [number, number], yMin?: number, yMax?: number) => SeriesPairMetadataAnalyzer;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fizz/paramodel",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fizz/breakdancer": "^0.24.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Data Models for ParaCharts",
   "contributors": [
     "Simon Varey",


### PR DESCRIPTION
Adds a useWorker option to Models. Set this option to false if you don't want to use WebWorkers for series analysis (for example, if you are in a Node.js context).