### PR TITLE
Add `PlaneSeries/Model`, Add `getChart/SeriesTheme`

### DIFF
--- a/etc/paramodel.api.md
+++ b/etc/paramodel.api.md
@@ -342,7 +342,7 @@ export function planeModelFromInlineData(manifest: Manifest, seriesAnalyzerConst
 export class Series {
     // (undocumented)
     [Symbol.iterator](): Iterator<Datapoint>;
-    constructor(manifest: SeriesManifest, rawData: RawDataPoint[], facetSignatures: FacetSignature[]);
+    constructor(manifest: SeriesManifest, rawData: RawDataPoint[], facetSignatures: FacetSignature[], indepKey?: string | undefined, depKey?: string | undefined);
     // (undocumented)
     [i: number]: Datapoint;
     // (undocumented)
@@ -357,6 +357,8 @@ export class Series {
     protected readonly _dataframe: DataFrame;
     // (undocumented)
     readonly datapoints: Datapoint[];
+    // (undocumented)
+    protected readonly depKey?: string | undefined;
     // (undocumented)
     facetAverage(key: string): number | null;
     // Warning: (ae-forgotten-export) The symbol "DataFrameColumn" needs to be exported by the entry point index.d.ts
@@ -377,6 +379,8 @@ export class Series {
     getLabel(): string;
     // (undocumented)
     readonly id: string;
+    // (undocumented)
+    protected readonly indepKey?: string | undefined;
     // (undocumented)
     readonly key: string;
     // (undocumented)

--- a/etc/paramodel.api.md
+++ b/etc/paramodel.api.md
@@ -284,10 +284,10 @@ export class PlaneDatapoint extends Datapoint {
 // Warning: (ae-forgotten-export) The symbol "PlaneModel" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export function planeModelFromExternalData(data: AllSeriesData, manifest: Manifest): PlaneModel;
+export function planeModelFromExternalData(data: AllSeriesData, manifest: Manifest, seriesAnalyzerConstructor?: SeriesAnalyzerConstructor, pairAnalyzerConstructor?: PairAnalyzerConstructor, useWorker?: boolean): PlaneModel;
 
 // @public (undocumented)
-export function planeModelFromInlineData(manifest: Manifest): PlaneModel;
+export function planeModelFromInlineData(manifest: Manifest, seriesAnalyzerConstructor?: SeriesAnalyzerConstructor, pairAnalyzerConstructor?: PairAnalyzerConstructor, useWorker?: boolean): PlaneModel;
 
 // @public (undocumented)
 export class Series {

--- a/etc/paramodel.api.md
+++ b/etc/paramodel.api.md
@@ -16,6 +16,7 @@ import { Manifest } from '@fizz/paramanifest';
 import { Point } from '@fizz/chart-classifier-utils';
 import type { SeriesAnalyzer } from '@fizz/series-analyzer';
 import { SeriesManifest } from '@fizz/paramanifest';
+import { Theme } from '@fizz/paramanifest';
 
 // Warning: (ae-forgotten-export) The symbol "SeriesPairMetadataAnalyzer" needs to be exported by the entry point index.d.ts
 //
@@ -218,11 +219,15 @@ export class Model {
     // (undocumented)
     readonly family: ChartTypeFamily;
     // (undocumented)
+    getChartTheme(): Theme | null;
+    // (undocumented)
     getFacet(key: string): Facet | null;
     // Warning: (ae-forgotten-export) The symbol "FacetStats" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
     getFacetStats(key: string): FacetStats | null;
+    // (undocumented)
+    getSeriesTheme(key: string): Theme | null;
     // (undocumented)
     readonly independentFacetKeys: string[];
     // (undocumented)
@@ -235,6 +240,10 @@ export class Model {
     readonly seriesKeys: string[];
     // (undocumented)
     protected _seriesMap: Record<string, Series>;
+    // (undocumented)
+    protected _seriesThemeMap: Record<string, Theme | undefined>;
+    // (undocumented)
+    protected _theme?: Theme;
     // (undocumented)
     readonly type: ChartType;
     // Warning: (ae-forgotten-export) The symbol "BoxSet" needs to be exported by the entry point index.d.ts
@@ -327,11 +336,6 @@ export class Series {
 
 // @public (undocumented)
 export type SeriesAnalyzerConstructor = new () => SeriesAnalyzer;
-
-// Warning: (ae-internal-missing-underscore) The name "strToId" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
-export function strToId(s: string): string;
 
 // @public
 export interface TrackingGroup {

--- a/etc/paramodel.api.md
+++ b/etc/paramodel.api.md
@@ -231,6 +231,8 @@ export class Model {
     // (undocumented)
     getSeriesTheme(key: string): Theme | null;
     // (undocumented)
+    hasExplictChartTheme(): boolean;
+    // (undocumented)
     readonly independentFacetKeys: string[];
     // (undocumented)
     readonly multi: boolean;

--- a/etc/paramodel.api.md
+++ b/etc/paramodel.api.md
@@ -9,14 +9,13 @@ import { ChartType } from '@fizz/paramanifest';
 import { ChartTypeFamily } from '@fizz/paramanifest';
 import { Dataset } from '@fizz/paramanifest';
 import { Datatype } from '@fizz/paramanifest';
+import { DisplayType } from '@fizz/paramanifest';
 import { Facet } from '@fizz/paramanifest';
 import { Line } from '@fizz/chart-classifier-utils';
 import { Manifest } from '@fizz/paramanifest';
 import { Point } from '@fizz/chart-classifier-utils';
-import { ScaledNumberRounded } from '@fizz/number-scaling-rounding';
-import type { SeriesAnalysis } from '@fizz/series-analyzer';
 import type { SeriesAnalyzer } from '@fizz/series-analyzer';
-import { Theme } from '@fizz/paramanifest';
+import { SeriesManifest } from '@fizz/paramanifest';
 
 // Warning: (ae-forgotten-export) The symbol "SeriesPairMetadataAnalyzer" needs to be exported by the entry point index.d.ts
 //
@@ -189,7 +188,7 @@ export interface Intersection {
 
 // @public (undocumented)
 export class Model {
-    constructor(series: Series[], manifest: Manifest, seriesAnalyzerConstructor?: SeriesAnalyzerConstructor | undefined, pairAnalyzerConstructor?: PairAnalyzerConstructor, _useWorker?: boolean);
+    constructor(series: Series[], manifest: Manifest);
     // (undocumented)
     [i: number]: Series;
     // (undocumented)
@@ -203,25 +202,21 @@ export class Model {
     // (undocumented)
     protected _axisFacetKeys: string[];
     // (undocumented)
-    readonly clusterOutliers: string[];
+    protected _dataset: Dataset;
     // (undocumented)
-    readonly clusters: string[][];
+    readonly dependentFacetKeys: string[];
     // (undocumented)
-    protected datatypeMap: Record<string, Datatype>;
+    protected _facetDatatypeMap: Record<string, Datatype>;
     // (undocumented)
-    dependentFacet: Facet | null;
+    protected _facetDisplayTypeMap: Record<string, DisplayType>;
     // (undocumented)
-    dependentFacetKey: string | null;
+    readonly facetKeys: string[];
     // (undocumented)
-    protected _facetKeys: string[];
+    protected _facetMap: Record<string, Facet>;
     // (undocumented)
-    readonly facetMap: Record<string, Facet>;
-    // (undocumented)
-    readonly facets: FacetSignature[];
+    readonly facetSignatures: FacetSignature[];
     // (undocumented)
     readonly family: ChartTypeFamily;
-    // (undocumented)
-    getAxisFacet(orientation: AxisOrientation): Facet | null;
     // (undocumented)
     getFacet(key: string): Facet | null;
     // Warning: (ae-forgotten-export) The symbol "FacetStats" needs to be exported by the entry point index.d.ts
@@ -229,23 +224,7 @@ export class Model {
     // (undocumented)
     getFacetStats(key: string): FacetStats | null;
     // (undocumented)
-    getSeriesAnalysis(key: string): Promise<SeriesAnalysis | null>;
-    // (undocumented)
-    readonly grouped: boolean;
-    // (undocumented)
-    protected _horizontalAxisFacetKey: string | null;
-    // (undocumented)
-    independentFacet: Facet | null;
-    // (undocumented)
-    independentFacetKey: string | null;
-    // (undocumented)
-    readonly intersections: Intersection[];
-    // (undocumented)
-    readonly intersectionScaledValues?: ScaledNumberRounded[];
-    // (undocumented)
-    protected keyMap: Record<string, Series>;
-    // (undocumented)
-    readonly keys: string[];
+    readonly independentFacetKeys: string[];
     // (undocumented)
     readonly multi: boolean;
     // (undocumented)
@@ -253,38 +232,22 @@ export class Model {
     // (undocumented)
     readonly series: Series[];
     // (undocumented)
-    seriesAnalysisMap?: Record<string, SeriesAnalysis>;
+    readonly seriesKeys: string[];
     // (undocumented)
-    seriesPairAnalyzer: SeriesPairMetadataAnalyzer | null;
-    // Warning: (ae-forgotten-export) The symbol "SeriesScaledValues" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    readonly seriesScaledValues?: SeriesScaledValues;
-    // Warning: (ae-forgotten-export) The symbol "AllSeriesStatsScaledValues" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    readonly seriesStatsScaledValues?: AllSeriesStatsScaledValues;
-    // (undocumented)
-    readonly theme: Theme;
-    // (undocumented)
-    readonly trackingGroups: TrackingGroup[];
-    // (undocumented)
-    readonly trackingZones: TrackingZone[];
+    protected _seriesMap: Record<string, Series>;
     // (undocumented)
     readonly type: ChartType;
+    // Warning: (ae-forgotten-export) The symbol "BoxSet" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
-    protected _useWorker: boolean;
-    // (undocumented)
-    protected _verticalAxisFacetKey: string | null;
-    // (undocumented)
-    readonly xy: boolean;
+    protected _uniqueValuesForFacet: Record<string, BoxSet<Datatype>>;
 }
 
 // @public (undocumented)
-export function modelFromExternalData(data: AllSeriesData, manifest: Manifest, seriesAnalyzerConstructor?: SeriesAnalyzerConstructor, pairAnalyzerConstructor?: PairAnalyzerConstructor, useWorker?: boolean): Model;
+export function modelFromExternalData(data: AllSeriesData, manifest: Manifest): Model;
 
 // @public (undocumented)
-export function modelFromInlineData(manifest: Manifest, seriesAnalyzerConstructor?: SeriesAnalyzerConstructor, pairAnalyzerConstructor?: PairAnalyzerConstructor, useWorker?: boolean): Model;
+export function modelFromInlineData(manifest: Manifest): Model;
 
 // @public (undocumented)
 export type PairAnalyzerConstructor = new (seriesArray: Line[], screenCoordSysSize: [number, number], yMin?: number, yMax?: number) => SeriesPairMetadataAnalyzer;
@@ -311,7 +274,7 @@ export class PlaneDatapoint extends Datapoint {
 export class Series {
     // (undocumented)
     [Symbol.iterator](): Iterator<Datapoint>;
-    constructor(key: string, rawData: RawDataPoint[], facets: FacetSignature[], label?: string, theme?: Theme);
+    constructor(manifest: SeriesManifest, rawData: RawDataPoint[], facetSignatures: FacetSignature[]);
     // (undocumented)
     [i: number]: Datapoint;
     // (undocumented)
@@ -319,17 +282,25 @@ export class Series {
     // (undocumented)
     protected constructDatapoint(data: DataFrameRow, seriesKey: string, datapointIndex: number): Datapoint;
     // (undocumented)
+    createLineFromFacets(xKey: string, yKey: string): Line | null;
+    // Warning: (ae-forgotten-export) The symbol "DataFrame" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    protected readonly _dataframe: DataFrame;
+    // (undocumented)
     readonly datapoints: Datapoint[];
     // (undocumented)
-    protected datatypeMap: Record<string, Datatype>;
+    facetAverage(key: string): number | null;
     // Warning: (ae-forgotten-export) The symbol "DataFrameColumn" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    facet(key: string): DataFrameColumn<Datatype> | null;
+    facetBoxes(key: string): DataFrameColumn<Datatype> | null;
     // (undocumented)
-    facetAverage(key: string): number | null;
+    protected readonly _facetDatatypeMappedByKey: Record<string, Datatype>;
     // (undocumented)
-    readonly facets: FacetSignature[];
+    readonly facetKeys: string[];
+    // (undocumented)
+    readonly facetSignatures: FacetSignature[];
     // (undocumented)
     getFacetDatatype(key: string): Datatype | null;
     // (undocumented)
@@ -344,12 +315,14 @@ export class Series {
     readonly label: string;
     // (undocumented)
     readonly length: number;
+    // (undocumented)
+    readonly manifest: SeriesManifest;
     // Warning: (ae-forgotten-export) The symbol "RawDataPoint" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
     readonly rawData: RawDataPoint[];
     // (undocumented)
-    readonly theme?: Theme;
+    protected readonly _uniqueValuesForFacetMappedByKey: Record<string, BoxSet<Datatype>>;
 }
 
 // @public (undocumented)

--- a/etc/paramodel.api.md
+++ b/etc/paramodel.api.md
@@ -14,6 +14,8 @@ import { Facet } from '@fizz/paramanifest';
 import { Line } from '@fizz/chart-classifier-utils';
 import { Manifest } from '@fizz/paramanifest';
 import { Point } from '@fizz/chart-classifier-utils';
+import { ScaledNumberRounded } from '@fizz/number-scaling-rounding';
+import type { SeriesAnalysis } from '@fizz/series-analyzer';
 import type { SeriesAnalyzer } from '@fizz/series-analyzer';
 import { SeriesManifest } from '@fizz/paramanifest';
 import { Theme } from '@fizz/paramanifest';
@@ -278,6 +280,14 @@ export class PlaneDatapoint extends Datapoint {
     // (undocumented)
     indepKey: string;
 }
+
+// Warning: (ae-forgotten-export) The symbol "PlaneModel" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export function planeModelFromExternalData(data: AllSeriesData, manifest: Manifest): PlaneModel;
+
+// @public (undocumented)
+export function planeModelFromInlineData(manifest: Manifest): PlaneModel;
 
 // @public (undocumented)
 export class Series {

--- a/etc/paramodel.api.md
+++ b/etc/paramodel.api.md
@@ -281,8 +281,57 @@ export class PlaneDatapoint extends Datapoint {
     indepKey: string;
 }
 
-// Warning: (ae-forgotten-export) The symbol "PlaneModel" needs to be exported by the entry point index.d.ts
-//
+// @public (undocumented)
+export class PlaneModel extends Model {
+    constructor(series: PlaneSeries[], manifest: Manifest, seriesAnalyzerConstructor?: SeriesAnalyzerConstructor | undefined, pairAnalyzerConstructor?: PairAnalyzerConstructor, _useWorker?: boolean);
+    // (undocumented)
+    [i: number]: PlaneSeries;
+    // (undocumented)
+    readonly clusterOutliers: string[];
+    // (undocumented)
+    readonly clusters: string[][];
+    // (undocumented)
+    getAxisFacet(orientation: AxisOrientation): Facet | null;
+    // (undocumented)
+    getSeriesAnalysis(key: string): Promise<SeriesAnalysis | null>;
+    // (undocumented)
+    readonly grouped: boolean;
+    // (undocumented)
+    horizontalAxisKey?: string;
+    // (undocumented)
+    readonly intersections: Intersection[];
+    // (undocumented)
+    readonly intersectionScaledValues?: ScaledNumberRounded[];
+    // Warning: (ae-forgotten-export) The symbol "PlaneSeries" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    series: PlaneSeries[];
+    // (undocumented)
+    protected _seriesAnalysisDone: boolean;
+    // (undocumented)
+    protected _seriesAnalysisMap?: Record<string, SeriesAnalysis>;
+    // (undocumented)
+    protected _seriesLineMap: Record<string, Line>;
+    // (undocumented)
+    protected _seriesPairAnalyzer: SeriesPairMetadataAnalyzer | null;
+    // Warning: (ae-forgotten-export) The symbol "SeriesScaledValues" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    readonly seriesScaledValues?: SeriesScaledValues;
+    // Warning: (ae-forgotten-export) The symbol "AllSeriesStatsScaledValues" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    readonly seriesStatsScaledValues?: AllSeriesStatsScaledValues;
+    // (undocumented)
+    readonly trackingGroups: TrackingGroup[];
+    // (undocumented)
+    readonly trackingZones: TrackingZone[];
+    // (undocumented)
+    protected _useWorker: boolean;
+    // (undocumented)
+    verticalAxisKey?: string;
+}
+
 // @public (undocumented)
 export function planeModelFromExternalData(data: AllSeriesData, manifest: Manifest, seriesAnalyzerConstructor?: SeriesAnalyzerConstructor, pairAnalyzerConstructor?: PairAnalyzerConstructor, useWorker?: boolean): PlaneModel;
 

--- a/etc/paramodel.api.md
+++ b/etc/paramodel.api.md
@@ -221,7 +221,7 @@ export class Model {
     // (undocumented)
     readonly family: ChartTypeFamily;
     // (undocumented)
-    getChartTheme(): Theme | null;
+    getChartTheme(): Theme;
     // (undocumented)
     getFacet(key: string): Facet | null;
     // Warning: (ae-forgotten-export) The symbol "FacetStats" needs to be exported by the entry point index.d.ts
@@ -248,6 +248,8 @@ export class Model {
     protected _seriesThemeMap: Record<string, Theme | undefined>;
     // (undocumented)
     protected _theme?: Theme;
+    // (undocumented)
+    readonly title?: string;
     // (undocumented)
     readonly type: ChartType;
     // Warning: (ae-forgotten-export) The symbol "BoxSet" needs to be exported by the entry point index.d.ts

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,7 @@
 
-export { Model, facetsFromDataset, modelFromInlineData, modelFromExternalData, planeModelFromInlineData,
-  planeModelFromExternalData, type SeriesAnalyzerConstructor, type PairAnalyzerConstructor } from './model/model';
+export { Model, PlaneModel, facetsFromDataset, modelFromInlineData, modelFromExternalData, 
+  planeModelFromInlineData, planeModelFromExternalData, type SeriesAnalyzerConstructor, 
+  type PairAnalyzerConstructor } from './model/model';
 export { Series } from './model/series';
 export { Datapoint, PlaneDatapoint } from './model/datapoint';
 export { enumerate, arrayEqualsBy, type AxisOrientation } from './utils';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,6 @@
 
-export { Model, facetsFromDataset, modelFromInlineData, modelFromExternalData, 
-  type SeriesAnalyzerConstructor, type PairAnalyzerConstructor } from './model/model';
+export { Model, facetsFromDataset, modelFromInlineData, modelFromExternalData, planeModelFromInlineData,
+  planeModelFromExternalData, type SeriesAnalyzerConstructor, type PairAnalyzerConstructor } from './model/model';
 export { Series } from './model/series';
 export { Datapoint, PlaneDatapoint } from './model/datapoint';
 export { enumerate, arrayEqualsBy, type AxisOrientation } from './utils';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,7 +3,7 @@ export { Model, facetsFromDataset, modelFromInlineData, modelFromExternalData,
   type SeriesAnalyzerConstructor, type PairAnalyzerConstructor } from './model/model';
 export { Series } from './model/series';
 export { Datapoint, PlaneDatapoint } from './model/datapoint';
-export { strToId, enumerate, arrayEqualsBy, type AxisOrientation } from './utils';
+export { enumerate, arrayEqualsBy, type AxisOrientation } from './utils';
 export { Box } from './dataframe/box';
 export type { FacetSignature } from './dataframe/dataframe';
 export { type CalendarPeriod, parseCalendar, calendarGoBack, calendarEquals, 

--- a/lib/metadata/metadata.ts
+++ b/lib/metadata/metadata.ts
@@ -15,7 +15,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.*/
 
 import * as ss from 'simple-statistics';
-import { XYSeries } from '../model/series';
+import { PlaneSeries } from '../model/series';
 import { OrderOfMagnitude, scaleAndRound, ScaledNumberRounded } from '@fizz/number-scaling-rounding';
 import { Intersection } from './pair_analyzer_interface';
 import { Datapoint } from '../model/datapoint';
@@ -78,7 +78,7 @@ export type GeneratedValues = [
 ]
 
 export function generateValues(
-  allSeries: XYSeries[], 
+  allSeries: PlaneSeries[], 
   intersections: Intersection[], 
   yMultiplier?: OrderOfMagnitude
 ): GeneratedValues {

--- a/lib/model/datapoint.ts
+++ b/lib/model/datapoint.ts
@@ -97,6 +97,7 @@ export class PlaneDatapoint extends Datapoint {
     return this.data[this.depKey];
   }
 
+  // TODO: Is this needed any more with PlaneSeries?
   convertToActualXYForLine(): Point {
     return this.convertFacetValuesToXYForLine(this.indepKey, this.depKey)!;
   }

--- a/lib/model/model.ts
+++ b/lib/model/model.ts
@@ -23,12 +23,13 @@ import { FacetSignature } from "../dataframe/dataframe";
 import { Box, BoxSet } from "../dataframe/box";
 import { AllSeriesStatsScaledValues, calculateFacetStats, FacetStats, generateValues, SeriesScaledValues } from "../metadata/metadata";
 import { Datapoint } from '../model/datapoint';
-import { PlaneSeries, Series, seriesFromSeriesManifest } from './series';
+import { PlaneSeries, planeSeriesFromSeriesManifest, Series, seriesFromSeriesManifest } from './series';
 import { Intersection, SeriesPairMetadataAnalyzer, TrackingGroup, TrackingZone } from '../metadata/pair_analyzer_interface';
 import { BasicSeriesPairMetadataAnalyzer } from '../metadata/basic_pair_analyzer';
 import { OrderOfMagnitude, ScaledNumberRounded } from '@fizz/number-scaling-rounding';
 import { Line } from '@fizz/chart-classifier-utils';
 
+// TODO: Remove these
 export type SeriesAnalyzerConstructor = new () => SeriesAnalyzer;
 export type PairAnalyzerConstructor = new (seriesArray: Line[], screenCoordSysSize: [number, number], yMin?: number, yMax?: number) => SeriesPairMetadataAnalyzer;
 
@@ -39,42 +40,42 @@ export class Model {
   public readonly type: ChartType;
   public readonly family: ChartTypeFamily;
   public readonly grouped: boolean;
-  public readonly keys: string[] = [];
-  public readonly facets: FacetSignature[];
+
+  public readonly facetSignatures: FacetSignature[];
+  public readonly facetKeys: string[] = [];
+  public readonly dependentFacetKeys: string[] = [];
+  public readonly independentFacetKeys: string[] = [];
+  public horizontalAxisKey?: string;
+  public verticalAxisKey?: string;
+
+  public readonly seriesKeys: string[] = [];
   public readonly multi: boolean;
   public readonly numSeries: number;
+  public seriesAnalysisMap?: Record<string, SeriesAnalysis>;
+
   public readonly allPoints: Datapoint[] = [];
-  public readonly theme: Theme;
   public readonly seriesScaledValues?: SeriesScaledValues;
   public readonly seriesStatsScaledValues?: AllSeriesStatsScaledValues;
-  public readonly intersectionScaledValues?: ScaledNumberRounded[];
+  public readonly intersectionScaledValues?: ScaledNumberRounded[];  
   public readonly intersections: Intersection[] = [];
   public readonly clusters: string[][] = [];
   public readonly clusterOutliers: string[] = [];
   public readonly trackingGroups: TrackingGroup[] = [];
   public readonly trackingZones: TrackingZone[] = [];
-  public readonly facetMap: Record<string, Facet> = {}; // FIXME: this shouldn't be exposed
-  public dependentFacetKey: string | null = null;
-  public independentFacetKey: string | null = null;
-  public dependentFacet: Facet | null = null;
-  public independentFacet: Facet | null = null;
-  private seriesLineMap: Record<string, Line> = {};
-  public seriesAnalysisMap?: Record<string, SeriesAnalysis>;
-  private seriesAnalysisDone = false;
+  //public seriesPairAnalyzer: SeriesPairMetadataAnalyzer | null = null;
 
-  public seriesPairAnalyzer: SeriesPairMetadataAnalyzer | null = null;
+  protected _dataset: Dataset;
 
-  protected keyMap: Record<string, Series> = {};
-  protected datatypeMap: Record<string, Datatype> = {};
-  private uniqueValuesForFacet: Record<string, BoxSet<Datatype>> = {};
-
-  protected _facetKeys: string[] = [];
+  protected _facetMap: Record<string, Facet> = {};
+  protected _facetDatatypeMap: Record<string, Datatype> = {};
+  protected _facetDisplayTypeMap: Record<string, DisplayType> = {};
+  protected _uniqueValuesForFacet: Record<string, BoxSet<Datatype>> = {};
   protected _axisFacetKeys: string[] = [];
-  protected _horizontalAxisFacetKey: string | null = null;
-  protected _verticalAxisFacetKey: string | null = null;
-  private _displayTypeForFacet: Record<string, DisplayType> = {};
 
-  private dataset: Dataset;
+  protected _seriesPairAnalyzer: SeriesPairMetadataAnalyzer | null = null;
+  protected _seriesMap: Record<string, Series> = {};
+  protected _seriesLineMap: Record<string, Line> = {};
+  protected _seriesAnalysisDone = false;
 
   /*public readonly xs: ScalarMap[X][];
   public readonly ys: number[];*/
@@ -89,93 +90,65 @@ export class Model {
     if (this.series.length === 0) {
       throw new Error('models must have at least one series');
     }
+
+    // Whole Chart
     this.multi = this.series.length > 1;
-    this.dataset = manifest.datasets[0];
-    this.type = this.dataset.type;
+    this._dataset = manifest.datasets[0];
+    this.type = this._dataset.type;
     this.family = CHART_FAMILY_MAP[this.type];
-    this.grouped = this.dataset.seriesRelations === 'grouped'; // Defaults to 'stacked'
-    if (this.dataset.chartTheme) {
-      this.theme = this.dataset.chartTheme;
-    } else if (!this.multi) {
-      this.theme = this.dataset.series[0].theme;
-    } else {
-      throw new Error('multi-series charts must have an overall theme');
-    }
+    this.grouped = this._dataset.seriesRelations === 'grouped'; // Defaults to 'stacked'
 
     // Facets
-    this.facets = this.series[0].facetSignatures;
-    this.facets.forEach((facet) => {
-      this._facetKeys.push(facet.key);
-      this.uniqueValuesForFacet[facet.key] = new BoxSet<Datatype>;
-      this.datatypeMap[facet.key] = facet.datatype;
+    this.facetSignatures = this.series[0].facetSignatures;
+    this.facetSignatures.forEach((facet) => {
+      this.facetKeys.push(facet.key);
+      this._uniqueValuesForFacet[facet.key] = new BoxSet<Datatype>;
+      this._facetDatatypeMap[facet.key] = facet.datatype;
     });
-    this._facetKeys.forEach((key) => {
-      const facetManifest = this.dataset.facets[key];
-      this._displayTypeForFacet[key] = facetManifest.displayType;
-      this.facetMap[key] = facetManifest;
+    this.facetKeys.forEach((key) => {
+      const facetManifest = this._dataset.facets[key];
+      this._facetDisplayTypeMap[key] = facetManifest.displayType;
+      this._facetMap[key] = facetManifest;
       if (facetManifest.variableType === 'dependent') {
-        if (this.dependentFacetKey === null) {
-          this.dependentFacetKey = key;
-          this.dependentFacet = facetManifest;
-        } else {
-          throw new Error('only one dependent facet allowed');
-        }
-      };
+        this.dependentFacetKeys.push(key);
+      }
       if (facetManifest.variableType === 'independent') {
-        if (this.independentFacetKey === null) {
-          this.independentFacetKey = key;
-          this.independentFacet = facetManifest;
-        } else {
-          throw new Error('only one dependent facet allowed');
-        }
-      };
+        this.independentFacetKeys.push(key);
+      }
       if (facetManifest.displayType.type === 'axis') {
-        this._axisFacetKeys.push(key);
-        if (facetManifest.displayType!.orientation === 'horizontal') {
-          if (this._horizontalAxisFacetKey === null) {
-            this._horizontalAxisFacetKey = key;
-          } else {
-            throw new Error('only one horizontal axis per chart');
-          }
-        } else if (facetManifest.displayType!.orientation === 'vertical') {
-          if (this._verticalAxisFacetKey === null) {
-            this._verticalAxisFacetKey = key;
-          } else {
-            console.log(this._verticalAxisFacetKey, key)
-            throw new Error('only one vertical axis per chart');
-          }
+        if (facetManifest.displayType.orientation === 'horizontal') {
+          this.horizontalAxisKey = key;
+        } else if (facetManifest.displayType.orientation === 'vertical') {
+          this.verticalAxisKey = key;
         }
       }
     });
     if (this._axisFacetKeys.length !== 0 && this._axisFacetKeys.length !== 2) {
-      throw new Error('charts must either have 2 or 0 axes')
-    }
-    if (this._horizontalAxisFacetKey === null || this._verticalAxisFacetKey === null) {
-      //this.setDefaultAxes();
+      throw new Error('charts must either have 2 or 0 axes');
     }
 
     // Series
     this.numSeries = this.series.length;
     for (const [aSeries, seriesIndex] of enumerate(this.series)) {
-      if (this.keys.includes(aSeries.key)) {
+      if (this.seriesKeys.includes(aSeries.key)) {
         throw new Error('every series in a model must have a unique key');
       }
       if (!arrayEqualsBy(
         (l, r) => (l.key === r.key) && (l.datatype === r.datatype), 
-        aSeries.facetSignatures, this.facets
+        aSeries.facetSignatures, this.facetSignatures
       )) {
         throw new Error('every series in a model must have the same facets');
       }
-      this.keys.push(aSeries.key);
+      this.seriesKeys.push(aSeries.key);
       this[seriesIndex] = aSeries;
-      this.keyMap[aSeries.key] = aSeries;
+      this._seriesMap[aSeries.key] = aSeries;
       this.allPoints.push(...aSeries);
-      Object.keys(this.uniqueValuesForFacet).forEach((facetKey) => {
-        this.uniqueValuesForFacet[facetKey].merge(aSeries.allFacetValues(facetKey)!);
+      Object.keys(this._uniqueValuesForFacet).forEach((facetKey) => {
+        this._uniqueValuesForFacet[facetKey].merge(aSeries.allFacetValues(facetKey)!);
       });
     }
 
-    if (this.xy && this.type !== 'scatter') {
+    /*if (this.xy && this.type !== 'scatter') {
       [this.seriesScaledValues, this.seriesStatsScaledValues, this.intersectionScaledValues] 
         = generateValues(this.series as PlaneSeries[], this.intersections, this.getAxisFacet('vert')?.multiplier as OrderOfMagnitude | undefined);
       for (const series of (this.series as PlaneSeries[])) {
@@ -189,7 +162,7 @@ export class Model {
         this.trackingGroups = this.seriesPairAnalyzer.getTrackingGroups();
         this.trackingZones = this.seriesPairAnalyzer.getTrackingZones();
       }
-    }
+    }*/
 
     /*this.xs = mergeUniqueBy(
       (lhs, rhs) => xDatatype === 'date'
@@ -208,8 +181,9 @@ export class Model {
 
   }
 
+  // TODO: Transfer to ParaLoader
   // Note that this method will do nothing if the default circumstances aren't met
-  private setDefaultAxes(): void {
+  /*private setDefaultAxes(): void {
     const independentAxes = this._axisFacetKeys.filter(
       (key) => this.dataset.facets[key].variableType === 'independent'
     );
@@ -236,26 +210,26 @@ export class Model {
         this._horizontalAxisFacetKey === 'x';
         this._verticalAxisFacetKey === 'y';
     }
-  }
+  }*/
 
   private async generateSeriesAnalyses(): Promise<void> {
-    if (this.seriesAnalysisDone) {
+    if (this._seriesAnalysisDone) {
       return;
     }
     const seriesAnalyzer = new this.seriesAnalyzerConstructor!();
     this.seriesAnalysisMap = {};
-    for (const seriesKey in this.seriesLineMap) {
+    for (const seriesKey in this._seriesLineMap) {
       this.seriesAnalysisMap[seriesKey] = await seriesAnalyzer.analyzeSeries(
-        this.seriesLineMap[seriesKey],
+        this._seriesLineMap[seriesKey],
         { useWorker: this._useWorker }
       );
     }
-    this.seriesAnalysisDone = true;
+    this._seriesAnalysisDone = true;
   }
 
   @Memoize()
   public atKey(key: string): Series | null {
-    return this.keyMap[key] ?? null;
+    return this._seriesMap[key] ?? null;
   }
   
   public atKeyAndIndex(key: string, index: number): Datapoint | null {
@@ -264,12 +238,12 @@ export class Model {
 
   @Memoize()
   public allFacetValues(key: string): Box<Datatype>[] | null {
-    return this.uniqueValuesForFacet[key]?.values ?? null;
+    return this._uniqueValuesForFacet[key]?.values ?? null;
   }
 
   @Memoize()
   public getFacetStats(key: string): FacetStats | null {
-    const facetDatatype = this.datatypeMap[key];
+    const facetDatatype = this._facetDatatypeMap[key];
     // Checks for both non-existent and non-numerical facets
     if (facetDatatype !== 'number') {
       return null;
@@ -280,17 +254,17 @@ export class Model {
   @Memoize()
   public getAxisFacet(orientation: AxisOrientation): Facet | null {
     if (orientation === 'horiz') {
-      return this._horizontalAxisFacetKey ? this.facetMap[this._horizontalAxisFacetKey] : null;
+      return this.horizontalAxisKey ? this._facetMap[this.horizontalAxisKey] : null;
     }
-    return this._verticalAxisFacetKey ? this.facetMap[this._verticalAxisFacetKey] : null;
+    return this.verticalAxisKey ? this._facetMap[this.verticalAxisKey] : null;
   }
 
   @Memoize()
   public getFacet(key: string): Facet | null {
-    return this.facetMap[key] ?? null;
+    return this._facetMap[key] ?? null;
   }
 
-  @Memoize()
+  /*@Memoize()
   public async getSeriesAnalysis(key: string): Promise<SeriesAnalysis | null> {
     if (!this.xy 
       || this.type === 'scatter' 
@@ -300,11 +274,54 @@ export class Model {
     }
     await this.generateSeriesAnalyses();
     return this.seriesAnalysisMap![key];
+  }*/
+}
+
+export class PlaneModel extends Model {
+  declare series: PlaneSeries[];
+  [i: number]: PlaneSeries;
+
+  public readonly seriesScaledValues?: SeriesScaledValues;
+  public readonly seriesStatsScaledValues?: AllSeriesStatsScaledValues;
+  public readonly intersectionScaledValues?: ScaledNumberRounded[];
+  public readonly intersections: Intersection[] = [];
+  public readonly clusters: string[][] = [];
+  public readonly clusterOutliers: string[] = [];
+  public readonly trackingGroups: TrackingGroup[] = [];
+  public readonly trackingZones: TrackingZone[] = [];
+
+  constructor(series: PlaneSeries[], manifest: Manifest) {
+    super(series, manifest);
+    
+    [this.seriesScaledValues, this.seriesStatsScaledValues, this.intersectionScaledValues] 
+      = generateValues(this.series, this.intersections, this.getAxisFacet('vert')?.multiplier as OrderOfMagnitude | undefined);
+
+    if (this.multi) {
+      const seriesArray = this.series.map((series) => series.getActualLine());
+      this._seriesPairAnalyzer = new BasicSeriesPairMetadataAnalyzer(seriesArray, [1,1]); //FIXME: screensize, max/min 
+      this.intersections = this._seriesPairAnalyzer.getIntersections();
+      this.clusters = this._seriesPairAnalyzer.getClusters();
+      this.clusterOutliers = this._seriesPairAnalyzer.getClusterOutliers();
+      this.trackingGroups = this._seriesPairAnalyzer.getTrackingGroups();
+      this.trackingZones = this._seriesPairAnalyzer.getTrackingZones();
+    }
   }
 }
 
 export function facetsFromDataset(dataset: Dataset): FacetSignature[] {
   return Object.keys(dataset.facets).map((key) => ({ key, datatype: dataset.facets[key].datatype }))
+}
+
+function axesFromDataset(dataset: Dataset): { independentAxisKey?: string, dependentAxisKey?: string } {
+  const independentAxisKey = Object.entries(dataset.facets)
+    .filter(([_facetKey, facet]) => facet.displayType.type === 'axis')
+    .filter(([_facetKey, facet]) => facet.variableType === 'independent')
+    .map(([facetKey, _facet]) => facetKey).at(0);
+  const dependentAxisKey = Object.entries(dataset.facets)
+    .filter(([_facetKey, facet]) => facet.displayType.type === 'axis')
+    .filter(([_facetKey, facet]) => facet.variableType === 'dependent')
+    .map(([facetKey, _facet]) => facetKey).at(0);
+  return { independentAxisKey, dependentAxisKey };
 }
 
 export function modelFromInlineData(
@@ -324,7 +341,6 @@ export function modelFromInlineData(
   return new Model(series, manifest, seriesAnalyzerConstructor, pairAnalyzerConstructor, useWorker);
 }
 
-// FIXME: This function does not include series labels (as seperate from series keys) or series themes
 export function modelFromExternalData(
   data: AllSeriesData, 
   manifest: Manifest, 
@@ -333,8 +349,40 @@ export function modelFromExternalData(
   useWorker = true
 ): Model {
   const facets = facetsFromDataset(manifest.datasets[0]);
-  const series = Object.keys(data).map((key) => 
-    new Series(key, data[key], facets)
-  );
+  const series = Object.keys(data).map((key) => {
+    const seriesManifest = manifest.datasets[0].series.filter((s) => s.key === key)[0];
+    return new Series(seriesManifest, data[key], facets);
+  });
   return new Model(series, manifest, seriesAnalyzerConstructor, pairAnalyzerConstructor, useWorker);
+
+}
+
+export function planeModelFromInlineData(manifest: Manifest): PlaneModel {
+  const dataset = manifest.datasets[0];
+  if (dataset.data.source !== 'inline') {
+    throw new Error('only manifests with inline data can use this function.');
+  }
+  const { independentAxisKey, dependentAxisKey } = axesFromDataset(dataset);
+  if (!independentAxisKey || !dependentAxisKey) {
+    throw new Error('only manifests with 2D axes can use this function.');
+  }
+  const facets = facetsFromDataset(dataset);
+  const series = dataset.series.map((seriesManifest) => 
+    planeSeriesFromSeriesManifest(seriesManifest, facets, independentAxisKey, dependentAxisKey)
+  );
+  return new PlaneModel(series, manifest);
+}
+
+export function planeModelFromExternalData(data: AllSeriesData, manifest: Manifest): PlaneModel {
+  const dataset = manifest.datasets[0];
+  const { independentAxisKey, dependentAxisKey } = axesFromDataset(dataset);
+  if (!independentAxisKey || !dependentAxisKey) {
+    throw new Error('only manifests with 2D axes can use this function.');
+  }
+  const facets = facetsFromDataset(dataset);
+  const series = Object.keys(data).map((key) => {
+    const seriesManifest = dataset.series.filter((s) => s.key === key)[0];
+    return new PlaneSeries(seriesManifest, data[key], facets, independentAxisKey, dependentAxisKey);
+  });
+  return new PlaneModel(series, manifest);
 }

--- a/lib/model/model.ts
+++ b/lib/model/model.ts
@@ -83,6 +83,7 @@ export class Model {
   public readonly allPoints: Datapoint[] = [];
 
   protected _dataset: Dataset;
+  protected _theme?: Theme;
 
   protected _facetMap: Record<string, Facet> = {};
   protected _facetDatatypeMap: Record<string, Datatype> = {};
@@ -91,6 +92,7 @@ export class Model {
   protected _axisFacetKeys: string[] = [];
 
   protected _seriesMap: Record<string, Series> = {};
+  protected _seriesThemeMap: Record<string, Theme | undefined> = {};
 
   constructor(public readonly series: Series[], manifest: Manifest) {
     if (this.series.length === 0) {
@@ -102,6 +104,7 @@ export class Model {
     this._dataset = manifest.datasets[0];
     this.type = this._dataset.type;
     this.family = CHART_FAMILY_MAP[this.type];
+    this._theme = this._dataset.chartTheme; // May be undefined 
 
     // Facets
     this.facetSignatures = this.series[0].facetSignatures;
@@ -144,6 +147,7 @@ export class Model {
       Object.keys(this._uniqueValuesForFacet).forEach((facetKey) => {
         this._uniqueValuesForFacet[facetKey].merge(aSeries.allFacetValues(facetKey)!);
       });
+      this._seriesThemeMap[aSeries.key] = aSeries.manifest.theme; // May be undefined
     }
   }
 
@@ -174,6 +178,16 @@ export class Model {
   @Memoize()
   public getFacet(key: string): Facet | null {
     return this._facetMap[key] ?? null;
+  }
+
+  @Memoize()
+  public getChartTheme(): Theme | null {
+    return this._theme ?? null;
+  }
+
+  @Memoize()
+  public getSeriesTheme(key: string): Theme | null {
+    return this._seriesThemeMap[key] ?? null;
   }
 }
 

--- a/lib/model/model.ts
+++ b/lib/model/model.ts
@@ -59,6 +59,7 @@ import { Intersection, SeriesPairMetadataAnalyzer, TrackingGroup, TrackingZone }
 import { BasicSeriesPairMetadataAnalyzer } from '../metadata/basic_pair_analyzer';
 import { OrderOfMagnitude, ScaledNumberRounded } from '@fizz/number-scaling-rounding';
 import { Line } from '@fizz/chart-classifier-utils';
+import { synthesizeChartTheme } from '../theme_synthesis';
 
 // TODO: Remove these
 export type SeriesAnalyzerConstructor = new () => SeriesAnalyzer;
@@ -182,7 +183,7 @@ export class Model {
 
   @Memoize()
   public getChartTheme(): Theme | null {
-    return this._theme ?? null;
+    return this._theme ?? synthesizeChartTheme(this);
   }
 
   @Memoize()

--- a/lib/model/model.ts
+++ b/lib/model/model.ts
@@ -59,7 +59,7 @@ import { Intersection, SeriesPairMetadataAnalyzer, TrackingGroup, TrackingZone }
 import { BasicSeriesPairMetadataAnalyzer } from '../metadata/basic_pair_analyzer';
 import { OrderOfMagnitude, ScaledNumberRounded } from '@fizz/number-scaling-rounding';
 import { Line } from '@fizz/chart-classifier-utils';
-import { synthesizeChartTheme } from '../theme_synthesis';
+import { synthesizeChartTheme, synthesizeSeriesTheme } from '../theme_synthesis';
 
 // TODO: Remove these
 export type SeriesAnalyzerConstructor = new () => SeriesAnalyzer;
@@ -182,13 +182,18 @@ export class Model {
   }
 
   @Memoize()
+  public hasExplictChartTheme(): boolean {
+    return this._theme !== undefined;
+  }
+
+  @Memoize()
   public getChartTheme(): Theme | null {
     return this._theme ?? synthesizeChartTheme(this);
   }
 
   @Memoize()
   public getSeriesTheme(key: string): Theme | null {
-    return this._seriesThemeMap[key] ?? null;
+    return this._seriesThemeMap[key] ?? synthesizeSeriesTheme(key, this);
   }
 }
 

--- a/lib/model/model.ts
+++ b/lib/model/model.ts
@@ -69,6 +69,8 @@ export type PairAnalyzerConstructor = new (seriesArray: Line[], screenCoordSysSi
 // TODO: In theory, facets should be a set, not an array. Maybe they should be sorted first?
 export class Model {
   [i: number]: Series;
+
+  public readonly title?: string;
   public readonly type: ChartType;
   public readonly family: ChartTypeFamily;
 
@@ -103,6 +105,7 @@ export class Model {
     // Whole Chart
     this.multi = this.series.length > 1;
     this._dataset = manifest.datasets[0];
+    this.title = this._dataset.title;
     this.type = this._dataset.type;
     this.family = CHART_FAMILY_MAP[this.type];
     this._theme = this._dataset.chartTheme; // May be undefined 
@@ -187,12 +190,15 @@ export class Model {
   }
 
   @Memoize()
-  public getChartTheme(): Theme | null {
+  public getChartTheme(): Theme {
     return this._theme ?? synthesizeChartTheme(this);
   }
 
   @Memoize()
   public getSeriesTheme(key: string): Theme | null {
+    if (this.atKey(key) === null) {
+      return null;
+    }
     return this._seriesThemeMap[key] ?? synthesizeSeriesTheme(key, this);
   }
 }

--- a/lib/model/model.ts
+++ b/lib/model/model.ts
@@ -348,7 +348,12 @@ export function modelFromExternalData(data: AllSeriesData, manifest: Manifest): 
 
 }
 
-export function planeModelFromInlineData(manifest: Manifest): PlaneModel {
+export function planeModelFromInlineData(
+  manifest: Manifest,
+  seriesAnalyzerConstructor?: SeriesAnalyzerConstructor,
+  pairAnalyzerConstructor?: PairAnalyzerConstructor,
+  useWorker?: boolean
+): PlaneModel {
   const dataset = manifest.datasets[0];
   if (dataset.data.source !== 'inline') {
     throw new Error('only manifests with inline data can use this function.');
@@ -361,10 +366,16 @@ export function planeModelFromInlineData(manifest: Manifest): PlaneModel {
   const series = dataset.series.map((seriesManifest) => 
     planeSeriesFromSeriesManifest(seriesManifest, facets, independentAxisKey, dependentAxisKey)
   );
-  return new PlaneModel(series, manifest);
+  return new PlaneModel(series, manifest, seriesAnalyzerConstructor, pairAnalyzerConstructor, useWorker);
 }
 
-export function planeModelFromExternalData(data: AllSeriesData, manifest: Manifest): PlaneModel {
+export function planeModelFromExternalData(
+  data: AllSeriesData, 
+  manifest: Manifest,
+  seriesAnalyzerConstructor?: SeriesAnalyzerConstructor,
+  pairAnalyzerConstructor?: PairAnalyzerConstructor,
+  useWorker?: boolean
+): PlaneModel {
   const dataset = manifest.datasets[0];
   const { independentAxisKey, dependentAxisKey } = axesFromDataset(dataset);
   if (!independentAxisKey || !dependentAxisKey) {
@@ -375,5 +386,5 @@ export function planeModelFromExternalData(data: AllSeriesData, manifest: Manife
     const seriesManifest = dataset.series.filter((s) => s.key === key)[0];
     return new PlaneSeries(seriesManifest, data[key], facets, independentAxisKey, dependentAxisKey);
   });
-  return new PlaneModel(series, manifest);
+  return new PlaneModel(series, manifest, seriesAnalyzerConstructor, pairAnalyzerConstructor, useWorker);
 }

--- a/lib/model/series.ts
+++ b/lib/model/series.ts
@@ -15,9 +15,8 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.*/
 
 import * as ss from 'simple-statistics';
-import { Datatype, SeriesManifest, Theme } from "@fizz/paramanifest";
+import { Datatype, SeriesManifest, strToId } from "@fizz/paramanifest";
 
-import { strToId } from "../utils";
 import { DataFrame, DataFrameColumn, DataFrameRow, FacetSignature, RawDataPoint } from "../dataframe/dataframe";
 import { Box, BoxSet, numberLikeDatatype } from "../dataframe/box";
 import { calculateFacetStats, FacetStats } from "../metadata/metadata";

--- a/lib/model/series.ts
+++ b/lib/model/series.ts
@@ -43,7 +43,9 @@ export class Series {
   constructor(
     public readonly manifest: SeriesManifest,
     public readonly rawData: RawDataPoint[], 
-    public readonly facetSignatures: FacetSignature[]
+    public readonly facetSignatures: FacetSignature[],
+    protected readonly indepKey?: string,
+    protected readonly depKey?: string
   ) {
     this.key = this.manifest.key;
     this.id = strToId(this.key); // TODO: see if we need to make this more unique
@@ -133,18 +135,20 @@ export class Series {
 
 export class PlaneSeries extends Series {
   declare datapoints: PlaneDatapoint[];
+  declare indepKey: string;
+  declare depKey: string;
   
   /*protected xMap: Map<ScalarMap[X], number[]>;
   private yMap: Map<number, ScalarMap[X][]>;*/
 
   constructor(
-    public readonly manifest: SeriesManifest,
-    public readonly rawData: RawDataPoint[], 
-    public readonly facetSignatures: FacetSignature[],
-    private readonly indepKey: string,
-    private readonly depKey: string
+    manifest: SeriesManifest,
+    rawData: RawDataPoint[], 
+    facetSignatures: FacetSignature[],
+    indepKey: string,
+    depKey: string
   ) {
-    super(manifest, rawData, facetSignatures);
+    super(manifest, rawData, facetSignatures, indepKey, depKey);
 
     console.assert(this.facetKeys.includes(indepKey), `[ParaModel/Internal]: PlaneSeries constructed with unknown indepKey ${indepKey}`);
     console.assert(this.facetKeys.includes(depKey), `[ParaModel/Internal]: PlaneSeries constructed with unknown depKey ${depKey}`);

--- a/lib/model/series.ts
+++ b/lib/model/series.ts
@@ -160,7 +160,7 @@ export class PlaneSeries extends Series {
   }
 
   @Memoize()
-  public createActualLine(): Line {
+  public getActualLine(): Line {
     return this.createLineFromFacets(this.indepKey, this.depKey)!;
   }
 

--- a/lib/model/series.ts
+++ b/lib/model/series.ts
@@ -27,91 +27,80 @@ import { Datapoint, PlaneDatapoint } from '../model/datapoint';
 
 export class Series {
   [i: number]: Datapoint;
-  public readonly length: number;
+
+  public readonly key: string;
   public readonly id: string;
   public readonly label: string;
-  public readonly theme?: Theme;
+
+  public readonly length: number;
   public readonly datapoints: Datapoint[] = [];
+  public readonly facetKeys: string[] = [];
 
-  private readonly dataframe: DataFrame;
-  private readonly uniqueValuesForFacet: Record<string, BoxSet<Datatype>> = {};
-  protected datatypeMap: Record<string, Datatype> = {};
+  protected readonly _dataframe: DataFrame;
 
-  /*protected xMap: Map<ScalarMap[X], number[]>;
-  private yMap: Map<number, ScalarMap[X][]>;*/
+  protected readonly _uniqueValuesForFacetMappedByKey: Record<string, BoxSet<Datatype>> = {};
+  protected readonly _facetDatatypeMappedByKey: Record<string, Datatype> = {};
 
   constructor(
-    public readonly key: string, 
+    public readonly manifest: SeriesManifest,
     public readonly rawData: RawDataPoint[], 
-    public readonly facets: FacetSignature[],
-    label?: string,
-    theme?: Theme
+    public readonly facetSignatures: FacetSignature[]
   ) {
-    this.dataframe = new DataFrame(facets);
-    this.facets.forEach((facet) => {
-      this.uniqueValuesForFacet[facet.key] = new BoxSet<Datatype>;
-      this.datatypeMap[facet.key] = facet.datatype;
+    this.key = this.manifest.key;
+    this.id = strToId(this.key); // TODO: see if we need to make this more unique
+    this.label = this.manifest.label ?? this.key;
+
+    this.facetSignatures.forEach((facet) => {
+      this.facetKeys.push(facet.key);
+      this._uniqueValuesForFacetMappedByKey[facet.key] = new BoxSet<Datatype>;
+      this._facetDatatypeMappedByKey[facet.key] = facet.datatype;
     });
-    this.rawData.forEach((datapoint) => this.dataframe.addDatapoint(datapoint));
-    this.dataframe.rows.forEach((row, index) => {
+
+    this._dataframe = new DataFrame(facetSignatures);
+    this.length = this.rawData.length;
+    this.rawData.forEach((datapoint) => this._dataframe.addDatapoint(datapoint));
+    this._dataframe.rows.forEach((row, index) => {
       const datapoint = this.constructDatapoint(row, this.key, index);
       this[index] = datapoint;
       this.datapoints.push(datapoint);
       Object.keys(row).forEach(
-        (facetKey) => this.uniqueValuesForFacet[facetKey].add(row[facetKey])
+        (facetKey) => this._uniqueValuesForFacetMappedByKey[facetKey].add(row[facetKey])
       );
     });
-    /*this.xMap = mapDatapointsXtoY(this.datapoints);
-    this.yMap = mapDatapointsYtoX(this.datapoints);*/
-    this.length = this.rawData.length;
-    this.id = strToId(this.key); // TODO: see if we need to make this more unique
-    this.label = label ?? this.key;
-    if (theme) {
-      this.theme = theme;
-    }
   }
 
   protected constructDatapoint(data: DataFrameRow, seriesKey: string, datapointIndex: number): Datapoint {
     return new Datapoint(data, seriesKey, datapointIndex);
   }
 
-  public facet(key: string): DataFrameColumn<Datatype> | null {
-    return this.dataframe.facet(key);
-  }
-
-  public allFacetValues(key: string): Box<Datatype>[] | null {
-    return this.uniqueValuesForFacet[key]?.values ?? null;
-  }
-
-  public getFacetDatatype(key: string): Datatype | null {
-    return this.datatypeMap[key] ?? null;
-  }
-
-  /*atX(x: ScalarMap[X]): number[] | null {
-    return this.xMap.get(x) ?? null;
-  }
-
-  atY(y: number): ScalarMap[X][] | null {
-    return this.yMap.get(y) ?? null;
-  }*/
-
-  [Symbol.iterator](): Iterator<Datapoint> {
-    return this.datapoints[Symbol.iterator]();
+  @Memoize()
+  public facetBoxes(key: string): DataFrameColumn<Datatype> | null {
+    return this._dataframe.facet(key);
   }
 
   @Memoize()
-  public getFacetStats(key: string): FacetStats | null {
-    const facetDatatype = this.datatypeMap[key];
-    // Checks for both non-existent and non-numerical facets
-    if (!numberLikeDatatype(facetDatatype)) {
+  public allFacetValues(key: string): Box<Datatype>[] | null {
+    return this._uniqueValuesForFacetMappedByKey[key]?.values ?? null;
+  }
+
+  @Memoize()
+  public getFacetDatatype(key: string): Datatype | null {
+    return this._facetDatatypeMappedByKey[key] ?? null;
+  }
+
+  // TODO: X and Y datatypes should be number-like
+  @Memoize()
+  public createLineFromFacets(xKey: string, yKey: string): Line | null {
+    if (!this.facetKeys.includes(xKey) || !this.facetKeys.includes(yKey)) {
       return null;
     }
-    return calculateFacetStats(key, this.datapoints);
+    const points = this.datapoints.map((point) => point.convertFacetValuesToXYForLine(xKey, yKey)!);
+    return new Line(points, this.key);
   }
 
   @Memoize()
   public facetAverage(key: string): number | null {
-    const facetDatatype = this.datatypeMap[key];
+    const facetDatatype = this._facetDatatypeMappedByKey[key];
     // Checks for both non-existent and non-numerical facets
     if (!numberLikeDatatype(facetDatatype)) {
       return null;
@@ -119,6 +108,21 @@ export class Series {
     return ss.mean(this.datapoints.map((point) => point.facetValueAsNumber(key)!));
   }
 
+  @Memoize()
+  public getFacetStats(key: string): FacetStats | null {
+    const facetDatatype = this._facetDatatypeMappedByKey[key];
+    // Checks for both non-existent and non-numerical facets
+    if (!numberLikeDatatype(facetDatatype)) {
+      return null;
+    }
+    return calculateFacetStats(key, this.datapoints);
+  }
+
+  [Symbol.iterator](): Iterator<Datapoint> {
+    return this.datapoints[Symbol.iterator]();
+  }
+
+  // Deprecated
   @Memoize()
   public getLabel(): string {
     if (this.label) {
@@ -128,56 +132,78 @@ export class Series {
   }
 }
 
-export class XYSeries extends Series {
+export class PlaneSeries extends Series {
   declare datapoints: PlaneDatapoint[];
+  
+  /*protected xMap: Map<ScalarMap[X], number[]>;
+  private yMap: Map<number, ScalarMap[X][]>;*/
 
   constructor(
-    key: string, 
-    rawData: RawDataPoint[], 
-    facets: FacetSignature[],
-    label?: string,
-    theme?: Theme
+    public readonly manifest: SeriesManifest,
+    public readonly rawData: RawDataPoint[], 
+    public readonly facetSignatures: FacetSignature[],
+    private readonly indepKey: string,
+    private readonly depKey: string
   ) {
-    super(key, rawData, facets, label, theme);
+    super(manifest, rawData, facetSignatures);
+
+    console.assert(this.facetKeys.includes(indepKey), `[ParaModel/Internal]: PlaneSeries constructed with unknown indepKey ${indepKey}`);
+    console.assert(this.facetKeys.includes(depKey), `[ParaModel/Internal]: PlaneSeries constructed with unknown depKey ${depKey}`);
+    console.assert(numberLikeDatatype(this.getFacetDatatype(depKey)), `[ParaModel/Internal]: PlaneSeries depKey ${depKey} has non-number-like ${this.getFacetDatatype(depKey)} datatype`);
+
+    /*this.xMap = mapDatapointsXtoY(this.datapoints);
+    this.yMap = mapDatapointsYtoX(this.datapoints);*/
+  }
+  
+  protected constructDatapoint(data: DataFrameRow, seriesKey: string, datapointIndex: number): Datapoint {
+    return new PlaneDatapoint(data, seriesKey, datapointIndex, this.indepKey, this.depKey);
   }
 
   @Memoize()
-  public getNumericalLine(): Line {
-    const points = this.datapoints.map((point) => point.convertToActualXYForLine());
-    return new Line(points, this.key);
+  public createActualLine(): Line {
+    return this.createLineFromFacets(this.indepKey, this.depKey)!;
   }
 
-  protected constructDatapoint(data: DataFrameRow, seriesKey: string, datapointIndex: number): Datapoint {
-    return new PlaneDatapoint(data, seriesKey, datapointIndex, 'x', 'y');
+  @Memoize()
+  public getIndepAverage(): number {
+    return this.facetAverage(this.indepKey)!;
   }
-}
 
-export function isXYFacetSignature(facets: FacetSignature[]): boolean {
-  const hasX = facets.some((facet) => facet.key === 'x');
-  const hasY = facets.some((facet) => facet.key === 'y');
-  return hasX && hasY;
+  // TODO: Add This
+  /*@Memoize()
+  public getAnalyzer(): SingleSeriesMetadataAnalyzer {
+    return new BasicSingleSeriesAnalyzer(this.createActualLine());
+  }*/
+
+  /*atX(x: ScalarMap[X]): number[] | null {
+    return this.xMap.get(x) ?? null;
+  }
+
+  atY(y: number): ScalarMap[X][] | null {
+    return this.yMap.get(y) ?? null;
+  }*/
 }
 
 export function seriesFromSeriesManifest(
-  seriesManifest: SeriesManifest, facets: FacetSignature[]
+  seriesManifest: SeriesManifest, facetSignatures: FacetSignature[]
 ): Series {
   if (!seriesManifest.records) {
     throw new Error('only series manifests with inline data can use this method.');
   }
-  if (isXYFacetSignature(facets)) {
-    return new XYSeries(
-      seriesManifest.key, 
-      seriesManifest.records!, 
-      facets,
-      seriesManifest.label,
-      seriesManifest.theme
-    );
+  return new Series(seriesManifest, seriesManifest.records!, facetSignatures);
+}
+
+export function planeSeriesFromSeriesManifest(
+  seriesManifest: SeriesManifest, facetSignatures: FacetSignature[], indepKey: string, depKey: string
+): PlaneSeries {
+  if (!seriesManifest.records) {
+    throw new Error('only series manifests with inline data can use this method.');
   }
-  return new Series(
-    seriesManifest.key, 
+  return new PlaneSeries(
+    seriesManifest, 
     seriesManifest.records!, 
-    facets,
-    seriesManifest.label,
-    seriesManifest.theme
-  )
+    facetSignatures,
+    indepKey,
+    depKey
+  );
 }

--- a/lib/theme_synthesis.ts
+++ b/lib/theme_synthesis.ts
@@ -1,4 +1,4 @@
-import { Theme } from "@fizz/paramanifest";
+import { BaseKind, Theme } from "@fizz/paramanifest";
 import { Model } from "./model/model";
 
 function decapitalize(titleStr: string): string {
@@ -8,21 +8,26 @@ function decapitalize(titleStr: string): string {
   return titleStr[0].toLowerCase() + titleStr.slice(1);
 }
 
-export function synthesizeChartTheme(model: Model): Theme | null {
-  if (!model.multi) {
-    return model.getSeriesTheme(model.seriesKeys[0]);
-  }
-  return null;
-}
-
-export function synthesizeSeriesTheme(seriesKey: string, model: Model): Theme | null {
-  if (!model.multi && model.hasExplictChartTheme()) {
-    return model.getChartTheme();
-  }
-  const baseKind = model.family === 'pastry' ? 'proportion' : 'number';
-  let baseQuantity = decapitalize(model.atKey(seriesKey)!.label);
+function synthesizeThemeFromLabel(label: string, baseKind: BaseKind): Theme {
+  let baseQuantity = decapitalize(label);
   if (baseKind === 'proportion' && baseQuantity.startsWith('proportion of ')) {
     baseQuantity = baseQuantity.slice('proportion of '.length);
   }
   return { baseQuantity, baseKind };
+}
+
+export function synthesizeChartTheme(model: Model): Theme {
+  if (!model.multi) {
+    return model.getSeriesTheme(model.seriesKeys[0])!;
+  }
+  const baseKind = model.family === 'pastry' ? 'proportion' : 'number';
+  return synthesizeThemeFromLabel(model.title ?? 'value', baseKind);
+}
+
+export function synthesizeSeriesTheme(seriesKey: string, model: Model): Theme {
+  if (!model.multi && model.hasExplictChartTheme()) {
+    return model.getChartTheme();
+  }
+  const baseKind = model.family === 'pastry' ? 'proportion' : 'number';
+  return synthesizeThemeFromLabel(model.atKey(seriesKey)!.label, baseKind);
 }

--- a/lib/theme_synthesis.ts
+++ b/lib/theme_synthesis.ts
@@ -1,0 +1,9 @@
+import { Theme } from "@fizz/paramanifest";
+import { Model } from "./model/model";
+
+export function synthesizeChartTheme(model: Model): Theme | null {
+  if (model.numSeries === 1) {
+    return model.getSeriesTheme(model.seriesKeys[0]);
+  }
+  return null;
+}

--- a/lib/theme_synthesis.ts
+++ b/lib/theme_synthesis.ts
@@ -1,9 +1,28 @@
 import { Theme } from "@fizz/paramanifest";
 import { Model } from "./model/model";
 
+function decapitalize(titleStr: string): string {
+  if (titleStr === '') {
+    return '';
+  }
+  return titleStr[0].toLowerCase() + titleStr.slice(1);
+}
+
 export function synthesizeChartTheme(model: Model): Theme | null {
-  if (model.numSeries === 1) {
+  if (!model.multi) {
     return model.getSeriesTheme(model.seriesKeys[0]);
   }
   return null;
+}
+
+export function synthesizeSeriesTheme(seriesKey: string, model: Model): Theme | null {
+  if (!model.multi && model.hasExplictChartTheme()) {
+    return model.getChartTheme();
+  }
+  const baseKind = model.family === 'pastry' ? 'proportion' : 'number';
+  let baseQuantity = decapitalize(model.atKey(seriesKey)!.label);
+  if (baseKind === 'proportion' && baseQuantity.startsWith('proportion of ')) {
+    baseQuantity = baseQuantity.slice('proportion of '.length);
+  }
+  return { baseQuantity, baseKind };
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -18,19 +18,6 @@ import { zip } from "@fizz/chart-classifier-utils";
 
 export type AxisOrientation = 'horiz' | 'vert';
 
-// ID Generation
-
-/**
- * Takes a string and normalizes it, stripping it of any non-alphanum characters and replacing its 
- *   whitespaces with underscores, so that can can serve as a DOM id.
- * @param {string} s A string, which may have spaces, punctuation, or other non-alphanum characters.
- * @returns {string} The unique string, stripped of all non-alphanum characters, to be used as an id.
- * @internal
- */
-export function strToId(s: string): string {
-  return s.toLowerCase().replace(/\s+/g, '_').replace(/[^\w-]+/g, '');
-}
-
 // Container Handling
 
 export function enumerate<T>(iterable: Iterable<T>): [T, number][] {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.4.7-alpha.3",
+  "version": "0.4.7-alpha.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fizz/paramodel",
-      "version": "0.4.7-alpha.3",
+      "version": "0.4.7-alpha.4",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fizz/breakdancer": "^0.24.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.4.7-alpha.5",
+  "version": "0.4.7-alpha.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fizz/paramodel",
-      "version": "0.4.7-alpha.5",
+      "version": "0.4.7-alpha.6",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fizz/breakdancer": "^0.24.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.4.7-alpha.1",
+  "version": "0.4.7-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fizz/paramodel",
-      "version": "0.4.7-alpha.1",
+      "version": "0.4.7-alpha.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fizz/breakdancer": "^0.24.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.4.7-alpha.4",
+  "version": "0.4.7-alpha.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fizz/paramodel",
-      "version": "0.4.7-alpha.4",
+      "version": "0.4.7-alpha.5",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fizz/breakdancer": "^0.24.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.4.6",
+  "version": "0.4.7-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fizz/paramodel",
-      "version": "0.4.6",
+      "version": "0.4.7-alpha.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fizz/breakdancer": "^0.24.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.4.7-alpha.0",
+  "version": "0.4.7-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fizz/paramodel",
-      "version": "0.4.7-alpha.0",
+      "version": "0.4.7-alpha.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fizz/breakdancer": "^0.24.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.4.7-alpha.2",
+  "version": "0.4.7-alpha.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fizz/paramodel",
-      "version": "0.4.7-alpha.2",
+      "version": "0.4.7-alpha.3",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fizz/breakdancer": "^0.24.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@fizz/chart-data": "^2.1.9",
         "@fizz/chart-message-candidates": "^0.28.1",
         "@fizz/number-scaling-rounding": "^0.5.0",
-        "@fizz/paramanifest": "^0.5.2",
+        "@fizz/paramanifest": "^0.5.3",
         "@fizz/test-utils": "^0.3.1",
         "simple-statistics": "^7.8.8",
         "typescript-memoize": "^1.1.1"
@@ -1508,9 +1508,9 @@
       }
     },
     "node_modules/@fizz/paramanifest": {
-      "version": "0.5.2",
-      "resolved": "https://npm.fizz.studio/@fizz/paramanifest/-/paramanifest-0.5.2.tgz",
-      "integrity": "sha512-HjlK7DUeHZIwLhpJD43opxvrc3kqiR77XASGmhg5AhZPXoHCFJzXiDyhdt2IfoXgV90NxcGbC1QbJ81qxt7lLA==",
+      "version": "0.5.3",
+      "resolved": "https://npm.fizz.studio/@fizz/paramanifest/-/paramanifest-0.5.3.tgz",
+      "integrity": "sha512-WNISZV8zAuD4l7N3tA5PkNhnhUujShqBQho30T69cr8fguRHRtfTNIB/lYFpjqFVMDBGvRuNMxdiHwAEwFyuag==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@hyperjump/json-pointer": "^1.1.0",
@@ -15579,9 +15579,9 @@
       }
     },
     "@fizz/paramanifest": {
-      "version": "0.5.2",
-      "resolved": "https://npm.fizz.studio/@fizz/paramanifest/-/paramanifest-0.5.2.tgz",
-      "integrity": "sha512-HjlK7DUeHZIwLhpJD43opxvrc3kqiR77XASGmhg5AhZPXoHCFJzXiDyhdt2IfoXgV90NxcGbC1QbJ81qxt7lLA==",
+      "version": "0.5.3",
+      "resolved": "https://npm.fizz.studio/@fizz/paramanifest/-/paramanifest-0.5.3.tgz",
+      "integrity": "sha512-WNISZV8zAuD4l7N3tA5PkNhnhUujShqBQho30T69cr8fguRHRtfTNIB/lYFpjqFVMDBGvRuNMxdiHwAEwFyuag==",
       "requires": {
         "@hyperjump/json-pointer": "^1.1.0",
         "@hyperjump/json-schema": "^1.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@fizz/chart-data": "^2.1.9",
         "@fizz/chart-message-candidates": "^0.28.1",
         "@fizz/number-scaling-rounding": "^0.5.0",
-        "@fizz/paramanifest": "^0.5.0",
+        "@fizz/paramanifest": "^0.5.2",
         "@fizz/test-utils": "^0.3.1",
         "simple-statistics": "^7.8.8",
         "typescript-memoize": "^1.1.1"
@@ -1508,9 +1508,9 @@
       }
     },
     "node_modules/@fizz/paramanifest": {
-      "version": "0.5.0",
-      "resolved": "https://npm.fizz.studio/@fizz/paramanifest/-/paramanifest-0.5.0.tgz",
-      "integrity": "sha512-nmM9KZoPAnj3jtI2Vsm9K0swhZYhNqz5QqwISiY77piR9CVFsgxFv+PWsSltiupoxLJD6FlUq+lUmIQYDtwafA==",
+      "version": "0.5.2",
+      "resolved": "https://npm.fizz.studio/@fizz/paramanifest/-/paramanifest-0.5.2.tgz",
+      "integrity": "sha512-HjlK7DUeHZIwLhpJD43opxvrc3kqiR77XASGmhg5AhZPXoHCFJzXiDyhdt2IfoXgV90NxcGbC1QbJ81qxt7lLA==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@hyperjump/json-pointer": "^1.1.0",
@@ -15579,9 +15579,9 @@
       }
     },
     "@fizz/paramanifest": {
-      "version": "0.5.0",
-      "resolved": "https://npm.fizz.studio/@fizz/paramanifest/-/paramanifest-0.5.0.tgz",
-      "integrity": "sha512-nmM9KZoPAnj3jtI2Vsm9K0swhZYhNqz5QqwISiY77piR9CVFsgxFv+PWsSltiupoxLJD6FlUq+lUmIQYDtwafA==",
+      "version": "0.5.2",
+      "resolved": "https://npm.fizz.studio/@fizz/paramanifest/-/paramanifest-0.5.2.tgz",
+      "integrity": "sha512-HjlK7DUeHZIwLhpJD43opxvrc3kqiR77XASGmhg5AhZPXoHCFJzXiDyhdt2IfoXgV90NxcGbC1QbJ81qxt7lLA==",
       "requires": {
         "@hyperjump/json-pointer": "^1.1.0",
         "@hyperjump/json-schema": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.4.7-alpha.2",
+  "version": "0.4.7-alpha.3",
   "description": "Data Models for ParaCharts",
   "contributors": [
     "Simon Varey",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@fizz/chart-data": "^2.1.9",
     "@fizz/chart-message-candidates": "^0.28.1",
     "@fizz/number-scaling-rounding": "^0.5.0",
-    "@fizz/paramanifest": "^0.5.0",
+    "@fizz/paramanifest": "^0.5.2",
     "@fizz/test-utils": "^0.3.1",
     "simple-statistics": "^7.8.8",
     "typescript-memoize": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.4.7-alpha.0",
+  "version": "0.4.7-alpha.1",
   "description": "Data Models for ParaCharts",
   "contributors": [
     "Simon Varey",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.4.7-alpha.5",
+  "version": "0.4.7-alpha.6",
   "description": "Data Models for ParaCharts",
   "contributors": [
     "Simon Varey",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.4.6",
+  "version": "0.4.7-alpha.0",
   "description": "Data Models for ParaCharts",
   "contributors": [
     "Simon Varey",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.4.7-alpha.3",
+  "version": "0.4.7-alpha.4",
   "description": "Data Models for ParaCharts",
   "contributors": [
     "Simon Varey",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@fizz/chart-data": "^2.1.9",
     "@fizz/chart-message-candidates": "^0.28.1",
     "@fizz/number-scaling-rounding": "^0.5.0",
-    "@fizz/paramanifest": "^0.5.2",
+    "@fizz/paramanifest": "^0.5.3",
     "@fizz/test-utils": "^0.3.1",
     "simple-statistics": "^7.8.8",
     "typescript-memoize": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.4.7-alpha.4",
+  "version": "0.4.7-alpha.5",
   "description": "Data Models for ParaCharts",
   "contributors": [
     "Simon Varey",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.4.7-alpha.1",
+  "version": "0.4.7-alpha.2",
   "description": "Data Models for ParaCharts",
   "contributors": [
     "Simon Varey",

--- a/src/stories/ModelPicker.ts
+++ b/src/stories/ModelPicker.ts
@@ -16,9 +16,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.*/
 
 import { customElement } from "lit/decorators.js";
 import { ManifestPicker, ManifestPickerProps } from "@fizz/test-utils";
-import { Manifest } from "@fizz/paramanifest";
+import { isPastryType, Manifest } from "@fizz/paramanifest";
 import { html, TemplateResult } from "lit";
-import { Model, modelFromInlineData } from "../../lib/index";
+import { Model, modelFromInlineData, planeModelFromInlineData } from "../../lib/index";
 import { SeriesAnalyzer } from "@fizz/series-analyzer";
 
 @customElement('model-picker')
@@ -27,7 +27,9 @@ export class ModelPicker extends ManifestPicker {
   private model?: Model;
 
   protected onManifestLoad(manifest: Manifest): void {
-    this.model = modelFromInlineData(manifest, SeriesAnalyzer);
+    this.model = isPastryType(manifest.datasets[0].type) 
+      ? modelFromInlineData(manifest)
+      : planeModelFromInlineData(manifest, SeriesAnalyzer)
   }
 
   protected renderManifest(manifest: Manifest): TemplateResult {


### PR DESCRIPTION
Adds `PlaneSeries` and `PlaneModel` for 2D chart models and their series, to complement the already existing `PlaneDatapoint`. All 3 have `indepKey` and `depKey` properties for their dependent and independent axis keys. All methods only relevant to 2D charts, including series trend analysis methods, have been moved to `PlaneSeries` and `PlaneModel`. Closes #8

Adds `getChartTheme` and `getSeriesTheme` to `Model`. This allows you to get a theme for a chart or series even if one has not been explicitly provided in the manifest. To do so, theme synthesis code has been added to the module. Closes #19

`key` is now used as the default for `label` in `Series.constructor`. Closes #15