### PR TITLE
Add `getChordAt` to PlaneModel

### DIFF
--- a/etc/paramodel.api.md
+++ b/etc/paramodel.api.md
@@ -89,6 +89,8 @@ export abstract class Box<T extends Datatype> {
     // (undocumented)
     abstract convertRaw(raw: string): ScalarMap[T];
     // (undocumented)
+    abstract datatype(): T;
+    // (undocumented)
     abstract isDate(): this is {
         value: CalendarPeriod;
     };
@@ -310,6 +312,8 @@ export class PlaneModel extends Model {
     // (undocumented)
     getAxisOrientation(depIndep: 'dependent' | 'independent'): AxisOrientation;
     // (undocumented)
+    getChordAt(facetKey: string, value: Box<Datatype>): Datapoint[] | null;
+    // (undocumented)
     getSeriesAnalysis(key: string): Promise<SeriesAnalysis | null>;
     // (undocumented)
     readonly grouped: boolean;
@@ -376,6 +380,8 @@ export class Series {
     //
     // (undocumented)
     protected readonly _dataframe: DataFrame;
+    // (undocumented)
+    datapointAt(facetKey: string, value: Box<Datatype>): Datapoint | null;
     // (undocumented)
     readonly datapoints: Datapoint[];
     // (undocumented)

--- a/lib/dataframe/box.ts
+++ b/lib/dataframe/box.ts
@@ -54,6 +54,8 @@ export abstract class Box<T extends Datatype> {
   abstract isNumberLike(): boolean;
 
   abstract asNumber(): number | null;
+
+  abstract datatype(): T;
 }
 
 /**
@@ -94,6 +96,9 @@ export class NumberBox extends Box<'number'> {
     return this.value;
   }
 
+  public datatype(): 'number' {
+    return 'number';
+  }
 }
 
 /**
@@ -130,6 +135,9 @@ export class StringBox extends Box<'string'> {
     return null;
   }
 
+  public datatype(): 'string' {
+    return 'string';
+  }
 }
 
 /**
@@ -170,6 +178,9 @@ export class DateBox extends Box<'date'> {
     return calendarNumber(this.value);
   }
 
+  public datatype(): 'date' {
+    return 'date';
+  }
 }
 
 type BoxConstructor<T extends Datatype> = new (raw: string) => Box<T>;

--- a/lib/metadata/metadata.ts
+++ b/lib/metadata/metadata.ts
@@ -99,7 +99,7 @@ export function generateValues(
 
   const rawValues = rawSeriesValues.concat(rawStatsValues);
 
-  rawValues.push(...intersections.map((intersection) => intersection.value))
+  rawValues.push(...intersections.map((intersection) => intersection.value));
 
   const scaled = scaleValues(yMultiplier ?? 1, rawValues);
 

--- a/lib/model/model.ts
+++ b/lib/model/model.ts
@@ -381,6 +381,16 @@ export class PlaneModel extends Model {
   public isPlaneModel(): this is PlaneModel {
     return true;
   }
+
+  @Memoize()
+  public getChordAt(facetKey: string, value: Box<Datatype>): Datapoint[] | null {
+    const datatype = this._facetDatatypeMap[facetKey];
+    if (datatype === undefined || value.datatype() !== datatype) {
+      return null;
+    }
+    return this.series.map((series) => series.datapointAt(facetKey, value))
+      .filter((datapoint) => datapoint !== null);
+  }
 }
 
 export function facetsFromDataset(dataset: Dataset): FacetSignature[] {

--- a/lib/model/model.ts
+++ b/lib/model/model.ts
@@ -383,7 +383,6 @@ export class PlaneModel extends Model {
     return true;
   }
 
-  @Memoize()
   public getChordAt(facetKey: string, value: Box<Datatype>): Datapoint[] | null {
     const datatype = this._facetDatatypeMap[facetKey];
     if (datatype === undefined || value.datatype() !== datatype) {

--- a/lib/model/model.ts
+++ b/lib/model/model.ts
@@ -275,8 +275,6 @@ export class PlaneModel extends Model {
       this.verticalAxisKey = this.dependentAxisKey;
     }
     if (this.type !== 'scatter') {
-      [this.seriesScaledValues, this.seriesStatsScaledValues, this.intersectionScaledValues] 
-        = generateValues(this.series, this.intersections, this.getAxisFacet('vert')?.multiplier as OrderOfMagnitude | undefined);
       for (const series of (this.series as PlaneSeries[])) {
         this._seriesLineMap[series.key] = series.getActualLine();
       }
@@ -294,6 +292,9 @@ export class PlaneModel extends Model {
         this.trackingGroups = this._seriesPairAnalyzer.getTrackingGroups();
         this.trackingZones = this._seriesPairAnalyzer.getTrackingZones();
       }
+      // NOTE: `generateValues` must come after `pairAnalyzer` as `generateValues` uses the intersections defined by `pairAnalyzer`
+      [this.seriesScaledValues, this.seriesStatsScaledValues, this.intersectionScaledValues] 
+        = generateValues(this.series, this.intersections, this.getAxisFacet('vert')?.multiplier as OrderOfMagnitude | undefined);
     }
 
     /*this.xs = mergeUniqueBy(

--- a/lib/model/series.ts
+++ b/lib/model/series.ts
@@ -123,6 +123,21 @@ export class Series {
     return this.datapoints[Symbol.iterator]();
   }
 
+  // Assumes at most one datapoint at that value at that facet
+  @Memoize()
+  public datapointAt(facetKey: string, value: Box<Datatype>): Datapoint | null {
+    const datatype = this._facetDatatypeMappedByKey[facetKey];
+    if (datatype === undefined || value.datatype() !== datatype) {
+      return null;
+    }
+    for (const datapoint of this.datapoints) {
+      if (datapoint.facetBox(facetKey)!.isEqual(value)) {
+        return datapoint;
+      }
+    }
+    return null;
+  }
+
   // Deprecated
   @Memoize()
   public getLabel(): string {

--- a/lib/model/series.ts
+++ b/lib/model/series.ts
@@ -124,7 +124,6 @@ export class Series {
   }
 
   // Assumes at most one datapoint at that value at that facet
-  @Memoize()
   public datapointAt(facetKey: string, value: Box<Datatype>): Datapoint | null {
     const datatype = this._facetDatatypeMappedByKey[facetKey];
     if (datatype === undefined || value.datatype() !== datatype) {

--- a/lib/model/series.ts
+++ b/lib/model/series.ts
@@ -131,7 +131,7 @@ export class Series {
       return null;
     }
     for (const datapoint of this.datapoints) {
-      console.log('datapointAt', datapoint, datapoint.facetBox(facetKey)!.isEqual(value))
+      console.log('datapointAt', datapoint, value, datapoint.facetBox(facetKey)!.isEqual(value))
       if (datapoint.facetBox(facetKey)!.isEqual(value)) {
         return datapoint;
       }

--- a/lib/model/series.ts
+++ b/lib/model/series.ts
@@ -131,6 +131,7 @@ export class Series {
       return null;
     }
     for (const datapoint of this.datapoints) {
+      console.log('datapointAt', datapoint, datapoint.facetBox(facetKey)!.isEqual(value))
       if (datapoint.facetBox(facetKey)!.isEqual(value)) {
         return datapoint;
       }

--- a/lib/model/series.ts
+++ b/lib/model/series.ts
@@ -130,7 +130,6 @@ export class Series {
       return null;
     }
     for (const datapoint of this.datapoints) {
-      console.log('datapointAt', datapoint, value, datapoint.facetBox(facetKey)!.isEqual(value))
       if (datapoint.facetBox(facetKey)!.isEqual(value)) {
         return datapoint;
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.5.8-alpha.4",
+  "version": "0.5.8-alpha.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fizz/paramodel",
-      "version": "0.5.8-alpha.4",
+      "version": "0.5.8-alpha.5",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fizz/breakdancer": "^0.24.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.5.8-alpha.0",
+  "version": "0.5.8-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fizz/paramodel",
-      "version": "0.5.8-alpha.0",
+      "version": "0.5.8-alpha.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fizz/breakdancer": "^0.24.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.5.8-alpha.3",
+  "version": "0.5.8-alpha.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fizz/paramodel",
-      "version": "0.5.8-alpha.3",
+      "version": "0.5.8-alpha.4",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fizz/breakdancer": "^0.24.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.5.7",
+  "version": "0.5.8-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fizz/paramodel",
-      "version": "0.5.7",
+      "version": "0.5.8-alpha.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fizz/breakdancer": "^0.24.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fizz/breakdancer": "^0.24.0",
         "@fizz/chart-classifier-utils": "^0.16.1",
-        "@fizz/chart-data": "^2.2.3",
+        "@fizz/chart-data": "^2.2.4",
         "@fizz/chart-message-candidates": "^0.28.1",
         "@fizz/number-scaling-rounding": "^0.5.2",
         "@fizz/paramanifest": "^0.5.8",
@@ -1261,9 +1261,9 @@
       }
     },
     "node_modules/@fizz/chart-data": {
-      "version": "2.2.3",
-      "resolved": "https://npm.fizz.studio/@fizz/chart-data/-/chart-data-2.2.3.tgz",
-      "integrity": "sha512-osY/wS+EtHLJG2c0nG4/e0oqdCQaMfIEdmTGfb2PyjgPI9B0eeYrSDItpYVJhpnP8FDbuKisMsElu+J7ExdF7Q==",
+      "version": "2.2.4",
+      "resolved": "https://npm.fizz.studio/@fizz/chart-data/-/chart-data-2.2.4.tgz",
+      "integrity": "sha512-tlLoLcMWqGlXy/4QbGAUoTtXK3GSvTTxmMtyjZklFNkpPkY+iqrzEWeAnv+oMoOxhlRqG4HW3sPviCgUw1/Pyw==",
       "license": "UNLICENSED",
       "dependencies": {
         "@fizz/chart-metadata-validation": "^2.0.5",
@@ -13828,9 +13828,9 @@
       }
     },
     "@fizz/chart-data": {
-      "version": "2.2.3",
-      "resolved": "https://npm.fizz.studio/@fizz/chart-data/-/chart-data-2.2.3.tgz",
-      "integrity": "sha512-osY/wS+EtHLJG2c0nG4/e0oqdCQaMfIEdmTGfb2PyjgPI9B0eeYrSDItpYVJhpnP8FDbuKisMsElu+J7ExdF7Q==",
+      "version": "2.2.4",
+      "resolved": "https://npm.fizz.studio/@fizz/chart-data/-/chart-data-2.2.4.tgz",
+      "integrity": "sha512-tlLoLcMWqGlXy/4QbGAUoTtXK3GSvTTxmMtyjZklFNkpPkY+iqrzEWeAnv+oMoOxhlRqG4HW3sPviCgUw1/Pyw==",
       "requires": {
         "@fizz/chart-metadata-validation": "^2.0.5",
         "@fizz/csv-processor": "^1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.5.8-alpha.1",
+  "version": "0.5.8-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fizz/paramodel",
-      "version": "0.5.8-alpha.1",
+      "version": "0.5.8-alpha.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fizz/breakdancer": "^0.24.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.5.8-alpha.2",
+  "version": "0.5.8-alpha.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fizz/paramodel",
-      "version": "0.5.8-alpha.2",
+      "version": "0.5.8-alpha.3",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fizz/breakdancer": "^0.24.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.5.8-alpha.5",
+  "version": "0.5.8-alpha.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fizz/paramodel",
-      "version": "0.5.8-alpha.5",
+      "version": "0.5.8-alpha.6",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fizz/breakdancer": "^0.24.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.5.8-alpha.1",
+  "version": "0.5.8-alpha.2",
   "description": "Data Models for ParaCharts",
   "contributors": [
     "Simon Varey",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.5.8-alpha.0",
+  "version": "0.5.8-alpha.1",
   "description": "Data Models for ParaCharts",
   "contributors": [
     "Simon Varey",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.5.8-alpha.4",
+  "version": "0.5.8-alpha.5",
   "description": "Data Models for ParaCharts",
   "contributors": [
     "Simon Varey",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.5.8-alpha.3",
+  "version": "0.5.8-alpha.4",
   "description": "Data Models for ParaCharts",
   "contributors": [
     "Simon Varey",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "dependencies": {
     "@fizz/breakdancer": "^0.24.0",
     "@fizz/chart-classifier-utils": "^0.16.1",
-    "@fizz/chart-data": "^2.2.3",
+    "@fizz/chart-data": "^2.2.4",
     "@fizz/chart-message-candidates": "^0.28.1",
     "@fizz/number-scaling-rounding": "^0.5.2",
     "@fizz/paramanifest": "^0.5.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.5.8-alpha.2",
+  "version": "0.5.8-alpha.3",
   "description": "Data Models for ParaCharts",
   "contributors": [
     "Simon Varey",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.5.8-alpha.5",
+  "version": "0.5.8-alpha.6",
   "description": "Data Models for ParaCharts",
   "contributors": [
     "Simon Varey",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.5.7",
+  "version": "0.5.8-alpha.0",
   "description": "Data Models for ParaCharts",
   "contributors": [
     "Simon Varey",


### PR DESCRIPTION
Adds a `getChordAt` method to PlaneModel so that the set of datapoints of all series at a particular facet value can be retrieved.