### PR TITLE
Added `nextDatapoint` and `prevDatapoint` methods

### DIFF
--- a/etc/paramodel.api.md
+++ b/etc/paramodel.api.md
@@ -229,7 +229,11 @@ export class Model {
     // (undocumented)
     readonly multi: boolean;
     // (undocumented)
+    nextDatapoint(datapoint: Datapoint): Datapoint | null;
+    // (undocumented)
     readonly numSeries: number;
+    // (undocumented)
+    prevDatapoint(datapoint: Datapoint): Datapoint | null;
     // (undocumented)
     readonly series: Series[];
     // (undocumented)

--- a/lib/model/model.ts
+++ b/lib/model/model.ts
@@ -216,6 +216,24 @@ export class Model {
   public isPlaneModel(): this is PlaneModel {
     return false;
   }
+
+  public prevDatapoint(datapoint: Datapoint): Datapoint | null {
+    const series = this.atKey(datapoint.seriesKey);
+    if (series === null) {
+      return null;
+    }
+    const prev = series.datapoints.at(datapoint.datapointIndex - 1);
+    return prev ?? null;
+  }
+
+  public nextDatapoint(datapoint: Datapoint): Datapoint | null {
+    const series = this.atKey(datapoint.seriesKey);
+    if (series === null) {
+      return null;
+    }
+    const next = series.datapoints.at(datapoint.datapointIndex + 1);
+    return next ?? null;
+  }
 }
 
 export class PlaneModel extends Model {


### PR DESCRIPTION
Adds `PlaneModel.nextDatapoint` and `PlaneModel.prevDatapoint` methods, which take a `Datapoint` and return the previous/next datapoint in the series