### PR TITLE
Add navcode to datapoints

### DIFF
--- a/etc/paramodel.api.md
+++ b/etc/paramodel.api.md
@@ -139,6 +139,8 @@ export class Datapoint {
     // (undocumented)
     facetValueNumericized(key: string): number | null;
     // (undocumented)
+    getNavcode(): string;
+    // (undocumented)
     seriesKey: string;
 }
 

--- a/etc/paramodel.api.md
+++ b/etc/paramodel.api.md
@@ -156,6 +156,18 @@ export type FacetSignature = {
     datatype: Datatype;
 };
 
+// @public (undocumented)
+export class GenericRangeBuilder<P> {
+    constructor(startPoint: P);
+    // (undocumented)
+    add(point: P): void;
+    // (undocumented)
+    points: P[];
+}
+
+// @public (undocumented)
+export function groupAdjacent<P>(points: P[], isStepBetween: (back: P, forward: P) => boolean): (P | GenericRangeBuilder<P>)[];
+
 // @public
 export interface Intersection {
     // Warning: (ae-forgotten-export) The symbol "Angle" needs to be exported by the entry point index.d.ts

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,7 +4,8 @@ export { Model, PlaneModel, facetsFromDataset, modelFromInlineData, modelFromExt
   type PairAnalyzerConstructor } from './model/model';
 export { Series } from './model/series';
 export { Datapoint, PlaneDatapoint } from './model/datapoint';
-export { enumerate, arrayEqualsBy, utcTimestampToPlainDateTime, type AxisOrientation } from './utils';
+export { enumerate, arrayEqualsBy, utcTimestampToPlainDateTime, groupAdjacent, 
+  type AxisOrientation, GenericRangeBuilder } from './utils';
 export { Box } from './dataframe/box';
 export type { FacetSignature } from './dataframe/dataframe';
 export type { Intersection, TrackingGroup } from './metadata/pair_analyzer_interface';

--- a/lib/model/datapoint.ts
+++ b/lib/model/datapoint.ts
@@ -74,6 +74,11 @@ export class Datapoint {
     return dataFrameRowEquals(this.data, other.data) 
       && this.seriesKey === other.seriesKey && this.datapointIndex === other.datapointIndex;
   }
+
+  @Memoize()
+  public getNavcode(): string {
+    return `datapoint-${this.seriesKey}-${this.datapointIndex}`;
+  }
 }
 
 export class PlaneDatapoint extends Datapoint {

--- a/lib/model/datapoint.ts
+++ b/lib/model/datapoint.ts
@@ -15,7 +15,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.*/
 
 import { Memoize } from "typescript-memoize";
-import { Datatype } from "@fizz/paramanifest";
+import { Datatype, strToId } from "@fizz/paramanifest";
 import { Point } from "@fizz/chart-classifier-utils";
 
 import { DataFrameRow, dataFrameRowEquals } from "../dataframe/dataframe";
@@ -77,7 +77,7 @@ export class Datapoint {
 
   @Memoize()
   public getNavcode(): string {
-    return `datapoint-${this.seriesKey}-${this.datapointIndex}`;
+    return `datapoint-${strToId(this.seriesKey)}-${this.datapointIndex}`;
   }
 }
 

--- a/lib/model/datapoint.ts
+++ b/lib/model/datapoint.ts
@@ -77,7 +77,7 @@ export class Datapoint {
 
   @Memoize()
   public getNavcode(): string {
-    return `datapoint-${strToId(this.seriesKey)}-${this.datapointIndex}`;
+    return `datapoint-${this.seriesKey}-${this.datapointIndex}`;
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.6.3-alpha.2",
+  "version": "0.6.3-alpha.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fizz/paramodel",
-      "version": "0.6.3-alpha.2",
+      "version": "0.6.3-alpha.3",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fizz/breakdancer": "^0.24.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.6.3-alpha.0",
+  "version": "0.6.3-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fizz/paramodel",
-      "version": "0.6.3-alpha.0",
+      "version": "0.6.3-alpha.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fizz/breakdancer": "^0.24.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.6.3-alpha.1",
+  "version": "0.6.3-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fizz/paramodel",
-      "version": "0.6.3-alpha.1",
+      "version": "0.6.3-alpha.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fizz/breakdancer": "^0.24.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.6.2",
+  "version": "0.6.3-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fizz/paramodel",
-      "version": "0.6.2",
+      "version": "0.6.3-alpha.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fizz/breakdancer": "^0.24.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.6.2",
+  "version": "0.6.3-alpha.0",
   "description": "Data Models for ParaCharts",
   "contributors": [
     "Simon Varey",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.6.3-alpha.0",
+  "version": "0.6.3-alpha.1",
   "description": "Data Models for ParaCharts",
   "contributors": [
     "Simon Varey",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.6.3-alpha.1",
+  "version": "0.6.3-alpha.2",
   "description": "Data Models for ParaCharts",
   "contributors": [
     "Simon Varey",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.6.3-alpha.2",
+  "version": "0.6.3-alpha.3",
   "description": "Data Models for ParaCharts",
   "contributors": [
     "Simon Varey",


### PR DESCRIPTION
Adds `getNavcode` method to datapoints. See https://github.com/fizzstudio/ParaCharts/issues/529

Also moves `groupAdjacent` here from ParaSummary