### PR TITLE
Converts `type` in manifest to use `representation` block

### DIFF
--- a/lib/model/model.ts
+++ b/lib/model/model.ts
@@ -112,7 +112,7 @@ export class Model {
     this._dataset = manifest.datasets[0];
     this.title = this._dataset.title;
     this.description = this._dataset.description; // May be undefined
-    this.type = this._dataset.type;
+    this.type = this._dataset.representation.subtype;
     this.family = CHART_FAMILY_MAP[this.type];
     this._theme = this._dataset.chartTheme; // May be undefined 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,13 +13,13 @@
         "@fizz/chart-classifier-utils": "^0.16.1",
         "@fizz/chart-message-candidates": "^0.28.1",
         "@fizz/number-scaling-rounding": "^0.5.2",
-        "@fizz/paramanifest": "^0.10.2-alpha.0",
+        "@fizz/paramanifest": "^0.10.2",
         "simple-statistics": "^7.8.8",
         "temporal-polyfill": "^0.3.0",
         "typescript-memoize": "^1.1.1"
       },
       "devDependencies": {
-        "@fizz/chart-data": "^2.3.8-alpha.1",
+        "@fizz/chart-data": "^2.4.1-alpha.1",
         "@fizz/test-utils": "^0.4.4",
         "@microsoft/api-documenter": "^7.26.4",
         "@microsoft/api-extractor": "^7.49.0",
@@ -1533,15 +1533,15 @@
       }
     },
     "node_modules/@fizz/chart-data": {
-      "version": "2.3.8-alpha.1",
-      "resolved": "https://npm.fizz.studio/@fizz/chart-data/-/chart-data-2.3.8-alpha.1.tgz",
-      "integrity": "sha512-STCPnSUC2kktHJDpC2+DNT+pYJe7v2LgN1qG1zET+4/imc88B6dbjLKaraHj5wm9RCKsA4+WrecCof7tW9u8aw==",
+      "version": "2.4.1-alpha.1",
+      "resolved": "https://npm.fizz.studio/@fizz/chart-data/-/chart-data-2.4.1-alpha.1.tgz",
+      "integrity": "sha512-8nGMvLmbU/Kq7W/pqBuevamyFrTbs/VPmbA4hma7Y6ln/tN8jCyIVmqENYgL4oQnk4SSX04gXvVWGi0bwe3a4w==",
       "dev": true,
       "license": "UNLICENSED",
       "dependencies": {
         "@fizz/chart-metadata-validation": "^2.0.5",
         "@fizz/csv-processor": "^1.3.0",
-        "@fizz/paramanifest": "^0.8.0"
+        "@fizz/paramanifest": "^0.10.2-alpha.0"
       }
     },
     "node_modules/@fizz/chart-data-norm": {
@@ -1550,20 +1550,6 @@
       "integrity": "sha512-YmBTWNT3w0yI53Hh2mwcVtCqHNamrwfaK/sfFZ3D2+7WYjBPl7SRHIaY0TWhTXuT2kzMuLc7IfG47xlbdUL9SA==",
       "license": "UNLICENSED",
       "optional": true
-    },
-    "node_modules/@fizz/chart-data/node_modules/@fizz/paramanifest": {
-      "version": "0.8.0",
-      "resolved": "https://npm.fizz.studio/@fizz/paramanifest/-/paramanifest-0.8.0.tgz",
-      "integrity": "sha512-qAtnGwv+pIKBXjjCUQunu1Ssxl3TfBDASw7syadTtIG1yQMeWcO0Zmpn0XwRmPkahF9rftsJRmjFBtEqCKp6Uw==",
-      "dev": true,
-      "license": "AGPL-3.0-or-later",
-      "dependencies": {
-        "@hyperjump/json-pointer": "^1.1.0",
-        "@hyperjump/json-schema": "^1.11.0",
-        "json-schema-static-docs": "^0.28.1",
-        "json-schema-to-typescript": "^15.0.4",
-        "jsonpath": "^1.1.1"
-      }
     },
     "node_modules/@fizz/chart-message": {
       "version": "0.19.0",
@@ -1701,9 +1687,9 @@
       }
     },
     "node_modules/@fizz/paramanifest": {
-      "version": "0.10.2-alpha.0",
-      "resolved": "https://npm.fizz.studio/@fizz/paramanifest/-/paramanifest-0.10.2-alpha.0.tgz",
-      "integrity": "sha512-vxVJozC+0jLEqCuoEjDDIR9/tGyR353lXH6FYV0S5XU9M14lmG+qDgLI0t9BXu7JaXclvE1Olx/4N9Tu/P/vLg==",
+      "version": "0.10.2",
+      "resolved": "https://npm.fizz.studio/@fizz/paramanifest/-/paramanifest-0.10.2.tgz",
+      "integrity": "sha512-Lq1s+sroBJHF26YOpexUYgI4O35WD2HPPugln7fuSdiewVio7A72OYUlbBRAZP6LulR6RZ1Iks/vS8n3RTcHMA==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@hyperjump/json-pointer": "^1.1.0",
@@ -15013,29 +14999,14 @@
       }
     },
     "@fizz/chart-data": {
-      "version": "2.3.8-alpha.1",
-      "resolved": "https://npm.fizz.studio/@fizz/chart-data/-/chart-data-2.3.8-alpha.1.tgz",
-      "integrity": "sha512-STCPnSUC2kktHJDpC2+DNT+pYJe7v2LgN1qG1zET+4/imc88B6dbjLKaraHj5wm9RCKsA4+WrecCof7tW9u8aw==",
+      "version": "2.4.1-alpha.1",
+      "resolved": "https://npm.fizz.studio/@fizz/chart-data/-/chart-data-2.4.1-alpha.1.tgz",
+      "integrity": "sha512-8nGMvLmbU/Kq7W/pqBuevamyFrTbs/VPmbA4hma7Y6ln/tN8jCyIVmqENYgL4oQnk4SSX04gXvVWGi0bwe3a4w==",
       "dev": true,
       "requires": {
         "@fizz/chart-metadata-validation": "^2.0.5",
         "@fizz/csv-processor": "^1.3.0",
-        "@fizz/paramanifest": "^0.8.0"
-      },
-      "dependencies": {
-        "@fizz/paramanifest": {
-          "version": "0.8.0",
-          "resolved": "https://npm.fizz.studio/@fizz/paramanifest/-/paramanifest-0.8.0.tgz",
-          "integrity": "sha512-qAtnGwv+pIKBXjjCUQunu1Ssxl3TfBDASw7syadTtIG1yQMeWcO0Zmpn0XwRmPkahF9rftsJRmjFBtEqCKp6Uw==",
-          "dev": true,
-          "requires": {
-            "@hyperjump/json-pointer": "^1.1.0",
-            "@hyperjump/json-schema": "^1.11.0",
-            "json-schema-static-docs": "^0.28.1",
-            "json-schema-to-typescript": "^15.0.4",
-            "jsonpath": "^1.1.1"
-          }
-        }
+        "@fizz/paramanifest": "^0.10.2-alpha.0"
       }
     },
     "@fizz/chart-data-norm": {
@@ -15153,9 +15124,9 @@
       }
     },
     "@fizz/paramanifest": {
-      "version": "0.10.2-alpha.0",
-      "resolved": "https://npm.fizz.studio/@fizz/paramanifest/-/paramanifest-0.10.2-alpha.0.tgz",
-      "integrity": "sha512-vxVJozC+0jLEqCuoEjDDIR9/tGyR353lXH6FYV0S5XU9M14lmG+qDgLI0t9BXu7JaXclvE1Olx/4N9Tu/P/vLg==",
+      "version": "0.10.2",
+      "resolved": "https://npm.fizz.studio/@fizz/paramanifest/-/paramanifest-0.10.2.tgz",
+      "integrity": "sha512-Lq1s+sroBJHF26YOpexUYgI4O35WD2HPPugln7fuSdiewVio7A72OYUlbBRAZP6LulR6RZ1Iks/vS8n3RTcHMA==",
       "requires": {
         "@hyperjump/json-pointer": "^1.1.0",
         "@hyperjump/json-schema": "^1.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@fizz/chart-classifier-utils": "^0.16.1",
         "@fizz/chart-message-candidates": "^0.28.1",
         "@fizz/number-scaling-rounding": "^0.5.2",
-        "@fizz/paramanifest": "^0.10.1",
+        "@fizz/paramanifest": "^0.10.2-alpha.0",
         "simple-statistics": "^7.8.8",
         "temporal-polyfill": "^0.3.0",
         "typescript-memoize": "^1.1.1"
@@ -42,6 +42,9 @@
         "typescript": "^5.7.2",
         "vite": "^6.3.5",
         "vitest": "^3.2.4"
+      },
+      "optionalDependencies": {
+        "@fizz/series-analyzer": "^0.13.9"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -1545,7 +1548,8 @@
       "version": "0.2.1",
       "resolved": "https://npm.fizz.studio/@fizz/chart-data-norm/-/chart-data-norm-0.2.1.tgz",
       "integrity": "sha512-YmBTWNT3w0yI53Hh2mwcVtCqHNamrwfaK/sfFZ3D2+7WYjBPl7SRHIaY0TWhTXuT2kzMuLc7IfG47xlbdUL9SA==",
-      "license": "UNLICENSED"
+      "license": "UNLICENSED",
+      "optional": true
     },
     "node_modules/@fizz/chart-data/node_modules/@fizz/paramanifest": {
       "version": "0.8.0",
@@ -1566,6 +1570,7 @@
       "resolved": "https://npm.fizz.studio/@fizz/chart-message/-/chart-message-0.19.0.tgz",
       "integrity": "sha512-1lpPczPFSf9s1ba/4eKl2Ve5Qs6DjHl1+qFhlzMSHOMM0KY8i9yHeuC4Om+z2o6kivd7MgITlb1JYHvZ01U/iQ==",
       "license": "UNLICENSED",
+      "optional": true,
       "dependencies": {
         "@fizz/chart-classifier-utils": "^0.16.0",
         "@fizz/jsbayes": "^0.6.1",
@@ -1664,19 +1669,22 @@
       "version": "0.6.1",
       "resolved": "https://npm.fizz.studio/@fizz/jsbayes/-/jsbayes-0.6.1.tgz",
       "integrity": "sha512-DvVi391YNrGPHXkKy+ogHjgajUjheYdF7D8XbPBEVaGUHnh+OyxOqwSQdit8U480YhGemtpNAEt++jE2dfTOtQ==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/@fizz/line-chart": {
       "version": "3.10.2",
       "resolved": "https://npm.fizz.studio/@fizz/line-chart/-/line-chart-3.10.2.tgz",
       "integrity": "sha512-Fdr5Hxhey7+y0ZGoMmXn4QSV2Wrju7ugUAoeGdQW3tRGZYnrD9R3/M3+lkeLN1zcSLHlyJsL6OhXWxUBHuueOA==",
-      "license": "UNLICENSED"
+      "license": "UNLICENSED",
+      "optional": true
     },
     "node_modules/@fizz/line-chart-ui-utils": {
       "version": "0.8.0",
       "resolved": "https://npm.fizz.studio/@fizz/line-chart-ui-utils/-/line-chart-ui-utils-0.8.0.tgz",
       "integrity": "sha512-Ro6w3x6Rk4ljgf0ATcXSwiSrr1eNS89AfBGZ0NM1A9L4vzjdEQP1LN1hulGE5fWZgKwgc16zE6KQI4JWLHcC+A==",
       "license": "UNLICENSED",
+      "optional": true,
       "dependencies": {
         "@fizz/chart-classifier-utils": "^0.16.0",
         "@fizz/chart-data-norm": "^0.2.1",
@@ -1693,9 +1701,9 @@
       }
     },
     "node_modules/@fizz/paramanifest": {
-      "version": "0.10.1",
-      "resolved": "https://npm.fizz.studio/@fizz/paramanifest/-/paramanifest-0.10.1.tgz",
-      "integrity": "sha512-xZCo+5nKIVTSEtxaG0m668Kdr1qcmBNEo2nt7COogjFTIfw1FRT5dnYlK2APGzMeqJ2vaI66IYq6bbmFN79IJw==",
+      "version": "0.10.2-alpha.0",
+      "resolved": "https://npm.fizz.studio/@fizz/paramanifest/-/paramanifest-0.10.2-alpha.0.tgz",
+      "integrity": "sha512-vxVJozC+0jLEqCuoEjDDIR9/tGyR353lXH6FYV0S5XU9M14lmG+qDgLI0t9BXu7JaXclvE1Olx/4N9Tu/P/vLg==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@hyperjump/json-pointer": "^1.1.0",
@@ -1721,6 +1729,7 @@
       "resolved": "https://npm.fizz.studio/@fizz/series-analyzer/-/series-analyzer-0.13.9.tgz",
       "integrity": "sha512-80s+L8v5bkBIeLlZy1J/bnCNhxV41i8+40kYaf87A8JWUHC55/KZp59dcoes8hyQk9+LH1rV/ADWoPvH7JApxw==",
       "license": "UNLICENSED",
+      "optional": true,
       "dependencies": {
         "@fizz/breakdancer": "^0.24.0",
         "@fizz/chart-classifier-utils": "^0.16.1",
@@ -15032,12 +15041,14 @@
     "@fizz/chart-data-norm": {
       "version": "0.2.1",
       "resolved": "https://npm.fizz.studio/@fizz/chart-data-norm/-/chart-data-norm-0.2.1.tgz",
-      "integrity": "sha512-YmBTWNT3w0yI53Hh2mwcVtCqHNamrwfaK/sfFZ3D2+7WYjBPl7SRHIaY0TWhTXuT2kzMuLc7IfG47xlbdUL9SA=="
+      "integrity": "sha512-YmBTWNT3w0yI53Hh2mwcVtCqHNamrwfaK/sfFZ3D2+7WYjBPl7SRHIaY0TWhTXuT2kzMuLc7IfG47xlbdUL9SA==",
+      "optional": true
     },
     "@fizz/chart-message": {
       "version": "0.19.0",
       "resolved": "https://npm.fizz.studio/@fizz/chart-message/-/chart-message-0.19.0.tgz",
       "integrity": "sha512-1lpPczPFSf9s1ba/4eKl2Ve5Qs6DjHl1+qFhlzMSHOMM0KY8i9yHeuC4Om+z2o6kivd7MgITlb1JYHvZ01U/iQ==",
+      "optional": true,
       "requires": {
         "@fizz/chart-classifier-utils": "^0.16.0",
         "@fizz/jsbayes": "^0.6.1",
@@ -15113,17 +15124,20 @@
     "@fizz/jsbayes": {
       "version": "0.6.1",
       "resolved": "https://npm.fizz.studio/@fizz/jsbayes/-/jsbayes-0.6.1.tgz",
-      "integrity": "sha512-DvVi391YNrGPHXkKy+ogHjgajUjheYdF7D8XbPBEVaGUHnh+OyxOqwSQdit8U480YhGemtpNAEt++jE2dfTOtQ=="
+      "integrity": "sha512-DvVi391YNrGPHXkKy+ogHjgajUjheYdF7D8XbPBEVaGUHnh+OyxOqwSQdit8U480YhGemtpNAEt++jE2dfTOtQ==",
+      "optional": true
     },
     "@fizz/line-chart": {
       "version": "3.10.2",
       "resolved": "https://npm.fizz.studio/@fizz/line-chart/-/line-chart-3.10.2.tgz",
-      "integrity": "sha512-Fdr5Hxhey7+y0ZGoMmXn4QSV2Wrju7ugUAoeGdQW3tRGZYnrD9R3/M3+lkeLN1zcSLHlyJsL6OhXWxUBHuueOA=="
+      "integrity": "sha512-Fdr5Hxhey7+y0ZGoMmXn4QSV2Wrju7ugUAoeGdQW3tRGZYnrD9R3/M3+lkeLN1zcSLHlyJsL6OhXWxUBHuueOA==",
+      "optional": true
     },
     "@fizz/line-chart-ui-utils": {
       "version": "0.8.0",
       "resolved": "https://npm.fizz.studio/@fizz/line-chart-ui-utils/-/line-chart-ui-utils-0.8.0.tgz",
       "integrity": "sha512-Ro6w3x6Rk4ljgf0ATcXSwiSrr1eNS89AfBGZ0NM1A9L4vzjdEQP1LN1hulGE5fWZgKwgc16zE6KQI4JWLHcC+A==",
+      "optional": true,
       "requires": {
         "@fizz/chart-classifier-utils": "^0.16.0",
         "@fizz/chart-data-norm": "^0.2.1",
@@ -15139,9 +15153,9 @@
       }
     },
     "@fizz/paramanifest": {
-      "version": "0.10.1",
-      "resolved": "https://npm.fizz.studio/@fizz/paramanifest/-/paramanifest-0.10.1.tgz",
-      "integrity": "sha512-xZCo+5nKIVTSEtxaG0m668Kdr1qcmBNEo2nt7COogjFTIfw1FRT5dnYlK2APGzMeqJ2vaI66IYq6bbmFN79IJw==",
+      "version": "0.10.2-alpha.0",
+      "resolved": "https://npm.fizz.studio/@fizz/paramanifest/-/paramanifest-0.10.2-alpha.0.tgz",
+      "integrity": "sha512-vxVJozC+0jLEqCuoEjDDIR9/tGyR353lXH6FYV0S5XU9M14lmG+qDgLI0t9BXu7JaXclvE1Olx/4N9Tu/P/vLg==",
       "requires": {
         "@hyperjump/json-pointer": "^1.1.0",
         "@hyperjump/json-schema": "^1.11.0",
@@ -15164,6 +15178,7 @@
       "version": "0.13.9",
       "resolved": "https://npm.fizz.studio/@fizz/series-analyzer/-/series-analyzer-0.13.9.tgz",
       "integrity": "sha512-80s+L8v5bkBIeLlZy1J/bnCNhxV41i8+40kYaf87A8JWUHC55/KZp59dcoes8hyQk9+LH1rV/ADWoPvH7JApxw==",
+      "optional": true,
       "requires": {
         "@fizz/breakdancer": "^0.24.0",
         "@fizz/chart-classifier-utils": "^0.16.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.6.21",
+  "version": "0.6.22-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fizz/paramodel",
-      "version": "0.6.21",
+      "version": "0.6.22-alpha.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fizz/breakdancer": "^0.24.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@fizz/chart-classifier-utils": "^0.16.1",
     "@fizz/chart-message-candidates": "^0.28.1",
     "@fizz/number-scaling-rounding": "^0.5.2",
-    "@fizz/paramanifest": "^0.10.1",
+    "@fizz/paramanifest": "^0.10.2-alpha.0",
     "simple-statistics": "^7.8.8",
     "temporal-polyfill": "^0.3.0",
     "typescript-memoize": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fizz/paramodel",
-  "version": "0.6.21",
+  "version": "0.6.22-alpha.0",
   "description": "Data Models for ParaCharts",
   "contributors": [
     "Simon Varey",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "types": "./dist/paramodel.d.ts",
   "devDependencies": {
-    "@fizz/chart-data": "^2.3.8-alpha.1",
+    "@fizz/chart-data": "^2.4.1-alpha.1",
     "@fizz/test-utils": "^0.4.4",
     "@microsoft/api-documenter": "^7.26.4",
     "@microsoft/api-extractor": "^7.49.0",
@@ -74,7 +74,7 @@
     "@fizz/chart-classifier-utils": "^0.16.1",
     "@fizz/chart-message-candidates": "^0.28.1",
     "@fizz/number-scaling-rounding": "^0.5.2",
-    "@fizz/paramanifest": "^0.10.2-alpha.0",
+    "@fizz/paramanifest": "^0.10.2",
     "simple-statistics": "^7.8.8",
     "temporal-polyfill": "^0.3.0",
     "typescript-memoize": "^1.1.1"


### PR DESCRIPTION
Converts `type` in manifest to use `representation` block, to align with JIM. See https://github.com/fizzstudio/ParaCharts/issues/891