### PR TITLE
Added helper functions

### DIFF
--- a/etc/paramodel.api.md
+++ b/etc/paramodel.api.md
@@ -190,6 +190,10 @@ export class DateBox extends Box<'date'> {
     isString(): this is {
         value: string;
     };
+    // (undocumented)
+    monthAbbrev(): string | undefined;
+    // (undocumented)
+    monthOrdinal(): string | undefined;
 }
 
 // Warning: (ae-forgotten-export) The symbol "DatePeriod" needs to be exported by the entry point index.d.ts

--- a/lib/dataframe/box.ts
+++ b/lib/dataframe/box.ts
@@ -18,6 +18,8 @@ import { Datatype } from "@fizz/paramanifest";
 
 import { ParaModelError } from "../utils";
 import { compareDateValues, convertStandardFormatToDateValue, DateValue, formatDateValue, 
+  getMonthAbbrev, 
+  getMonthOrdinal, 
   parseDateToStandardFormat } from "./date";
 
 // TODO: This type lacks a completeness type check. This could be implemented by testing in Vitest
@@ -214,6 +216,14 @@ export class DateBox extends Box<'date'> {
 
   public datatype(): 'date' {
     return 'date';
+  }
+
+  public monthAbbrev(): string | undefined {
+    return getMonthAbbrev(this.value);
+  }
+
+  public monthOrdinal(): string | undefined {
+    return getMonthOrdinal(this.value);
   }
 }
 

--- a/lib/dataframe/date.ts
+++ b/lib/dataframe/date.ts
@@ -145,3 +145,20 @@ export function formatDateValue(dateVal: DateValue, abbrev?: boolean): string {
   }
   return 'RECURRING DATES NOT IMPLEMENTED YET';
 }
+
+export function getMonthAbbrev(dateVal: DateValue): string | undefined {
+  if (dateVal.type !== 'date' || dateVal.duration.toString() !== 'P3M') {
+    return undefined;
+  }
+  const quarterNumber = (dateVal.start.month - 1) / 3;
+  return `Q${quarterNumber + 1}`;
+}
+
+export function getMonthOrdinal(dateVal: DateValue): string | undefined {
+  if (dateVal.type !== 'date' || dateVal.duration.toString() !== 'P3M') {
+    return undefined;
+  }
+  const quarterNumber = (dateVal.start.month - 1) / 3;
+  const quarterOrdinal = ['first', 'second', 'third', 'fourth'][quarterNumber];
+  return quarterOrdinal;
+}


### PR DESCRIPTION
Adds two functions on `DateBox` which return, for example, `Q1` and `first` for the full date `Q1 2018` for use in summarization