### PR TITLE
Changes topic synthesis to take into account `undefined` base kinds

### DIFF
--- a/lib/topic_synthesis.ts
+++ b/lib/topic_synthesis.ts
@@ -1,10 +1,15 @@
 import { BaseKind, Topic } from "@fizz/paramanifest";
-import { uncapitalize } from "@fizz/templum";
+//import { uncapitalize } from "@fizz/templum";
 
 import { Model } from "./model/model";
 
 function synthesizeTopicFromLabel(label: string, baseKind: BaseKind): Topic {
-  let baseQuantity = uncapitalize(label);
+  // TODO (@simonvarey): Labels will usually be capitalized, regardless of what sort of word they are.
+  //   The label was originally uncapitalized due to this fact, but this will produce the wrong result
+  //   for words that should always be capitalized, i.e. Proper Nouns like 'Vietnam' or 'Fizz Studio'.
+  //   I am currently not sure how to fix this, so I have temporarily removed uncapitalization as the
+  //   safest option.
+  let baseQuantity = label; //uncapitalize(label);
   if (baseKind === 'proportion' && baseQuantity.startsWith('proportion of ')) {
     baseQuantity = baseQuantity.slice('proportion of '.length);
   }
@@ -15,7 +20,7 @@ export function synthesizeChartTopic(model: Model): Topic {
   if (!model.multi) {
     return model.getSeriesTopic(model.seriesKeys[0])!;
   }
-  const baseKind = model.family === 'pastry' ? 'proportion' : 'number';
+  const baseKind = model.family === 'pastry' ? 'proportion' : undefined;
   return synthesizeTopicFromLabel(model.title ?? 'value', baseKind);
 }
 


### PR DESCRIPTION
Changes topic synthesis to take into account `undefined` base kinds by not synthesizing a `number` base kind (except for pastry charts, which are still synthesized a `proportion` base kind).

Needs to be ported to ChartSignal