### PR TITLE
Add exception, bump clustering

### DIFF
--- a/etc/paramodel.api.md
+++ b/etc/paramodel.api.md
@@ -492,7 +492,7 @@ export function planeModelFromInlineData(manifest: Manifest, seriesAnalyzerConst
 // @public (undocumented)
 export class PlaneSeries extends Series {
     // Warning: (ae-forgotten-export) The symbol "RawDatapoint" needs to be exported by the entry point index.d.ts
-    constructor(manifest: SeriesManifest, rawData: RawDatapoint[], facetSignatures: FacetSignature[], indepKey: string, depKey: string);
+    constructor(manifest: SeriesManifest, rawData: RawDatapoint[], facetSignatures: FacetSignature[], indepKey: string, depKey: string, type: string);
     // (undocumented)
     [i: number]: PlaneDatapoint;
     // (undocumented)
@@ -513,13 +513,15 @@ export class PlaneSeries extends Series {
     indepKey: string;
     // (undocumented)
     intersections: Intersection[];
+    // (undocumented)
+    type: string;
 }
 
 // @public (undocumented)
 export class Series {
     // (undocumented)
     [Symbol.iterator](): Iterator<Datapoint>;
-    constructor(manifest: SeriesManifest, rawData: RawDatapoint[], facetSignatures: FacetSignature[], indepKey?: string | undefined, depKey?: string | undefined);
+    constructor(manifest: SeriesManifest, rawData: RawDatapoint[], facetSignatures: FacetSignature[], indepKey?: string | undefined, depKey?: string | undefined, type?: string | undefined);
     // (undocumented)
     [i: number]: Datapoint;
     // (undocumented)
@@ -578,6 +580,8 @@ export class Series {
     //
     // (undocumented)
     statsScaledValues: SeriesStatsScaledValues | null;
+    // (undocumented)
+    protected type?: string | undefined;
     // (undocumented)
     protected readonly _uniqueValuesForFacetMappedByKey: Record<string, BoxSet<Datatype>>;
 }

--- a/lib/dataframe/box.ts
+++ b/lib/dataframe/box.ts
@@ -17,10 +17,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.*/
 import { Datatype } from "@fizz/paramanifest";
 
 import { ParaModelError } from "../utils";
-import { compareDateValues, convertStandardFormatToDateValue, DateValue, formatDateValue, 
-  getMonthAbbrev, 
-  getMonthOrdinal, 
-  parseDateToStandardFormat } from "./date";
+import {
+  compareDateValues, convertStandardFormatToDateValue, DateValue, formatDateValue,
+  getMonthAbbrev,
+  getMonthOrdinal,
+  parseDateToStandardFormat
+} from "./date";
 
 // TODO: This type lacks a completeness type check. This could be implemented by testing in Vitest
 // that `keyof ScalarMap extends Datatype` and vice versa and `ScalarMap[Datatype] extends Scalar` 
@@ -41,18 +43,18 @@ export function numberLikeDatatype(datatype: Datatype | null): boolean {
  */
 export abstract class Box<T extends Datatype> {
   public readonly value: ScalarMap[T];
-  
+
   constructor(public readonly raw: string) {
     this.value = this.convertRaw(raw);
   }
 
   abstract convertRaw(raw: string): ScalarMap[T];
 
-  abstract isNumber(): this is {value: number};
+  abstract isNumber(): this is { value: number };
 
-  abstract isString(): this is {value: string};
+  abstract isString(): this is { value: string };
 
-  abstract isDate(): this is {value: DateValue};
+  abstract isDate(): this is { value: DateValue };
 
   abstract isEqual(other: Box<T>): boolean;
 
@@ -81,15 +83,15 @@ export class NumberBox extends Box<'number'> {
     return val;
   }
 
-  public isNumber(): this is {value: number} {
+  public isNumber(): this is { value: number } {
     return true;
   }
 
-  public isString(): this is {value: string} {
+  public isString(): this is { value: string } {
     return false;
   }
 
-  public isDate(): this is {value: DateValue} {
+  public isDate(): this is { value: DateValue } {
     return false;
   }
 
@@ -127,16 +129,16 @@ export class StringBox extends Box<'string'> {
   convertRaw(raw: string): string {
     return raw;
   }
-  
-  public isNumber(): this is {value: number} {
+
+  public isNumber(): this is { value: number } {
     return false;
   }
 
-  public isString(): this is {value: string} {
+  public isString(): this is { value: string } {
     return true;
   }
 
-  public isDate(): this is {value: DateValue} {
+  public isDate(): this is { value: DateValue } {
     return false;
   }
 
@@ -178,16 +180,16 @@ export class DateBox extends Box<'date'> {
     }
     return convertStandardFormatToDateValue(standardFormat);
   }
-  
-  public isNumber(): this is {value: number} {
+
+  public isNumber(): this is { value: number } {
     return false;
   }
 
-  public isString(): this is {value: string} {
+  public isString(): this is { value: string } {
     return false;
   }
 
-  public isDate(): this is {value: DateValue} {
+  public isDate(): this is { value: DateValue } {
     return true;
   }
 
@@ -248,13 +250,17 @@ export class BoxSet<T extends Datatype> {
     return this.boxes.some((otherBox) => box.isEqual(otherBox));
   }
 
-  public add(box: Box<T>): void {
+  public add(box: Box<T>, unique = true): void {
+    if (!unique) {
+      this.boxes.push(box)
+      return;
+    }
     if (!this.has(box)) {
       this.boxes.push(box);
     }
   }
 
-  public merge(boxes: Box<T>[]): void {
-    boxes.forEach((box) => this.add(box));
+  public merge(boxes: Box<T>[], unique = false): void {
+    boxes.forEach((box) => this.add(box, unique));
   }
 }

--- a/lib/model/model.ts
+++ b/lib/model/model.ts
@@ -14,48 +14,52 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.*/
 
-  // TODO: Transfer to ParaLoader
-  // Note that this method will do nothing if the default circumstances aren't met
-  /*private setDefaultAxes(): void {
-    const independentAxes = this._axisFacetKeys.filter(
-      (key) => this.dataset.facets[key].variableType === 'independent'
-    );
-    const dependentAxes = this._axisFacetKeys.filter(
-      (key) => this.dataset.facets[key].variableType === 'dependent'
-    );
-    if (
-      independentAxes.length === 1 && 
-      dependentAxes.length === 1 &&
-      (this._horizontalAxisFacetKey === null || this._horizontalAxisFacetKey === independentAxes[0]) &&
-      (this._verticalAxisFacetKey === null || this._verticalAxisFacetKey === dependentAxes[0]) 
-    ) {
+// TODO: Transfer to ParaLoader
+// Note that this method will do nothing if the default circumstances aren't met
+/*private setDefaultAxes(): void {
+  const independentAxes = this._axisFacetKeys.filter(
+    (key) => this.dataset.facets[key].variableType === 'independent'
+  );
+  const dependentAxes = this._axisFacetKeys.filter(
+    (key) => this.dataset.facets[key].variableType === 'dependent'
+  );
+  if (
+    independentAxes.length === 1 && 
+    dependentAxes.length === 1 &&
+    (this._horizontalAxisFacetKey === null || this._horizontalAxisFacetKey === independentAxes[0]) &&
+    (this._verticalAxisFacetKey === null || this._verticalAxisFacetKey === dependentAxes[0]) 
+  ) {
+    // NOTE: One (but not both) of these might be rewriting the axis facet key to the same thing
+    this._horizontalAxisFacetKey = independentAxes[0];
+    this._verticalAxisFacetKey = dependentAxes[0];
+  } else if (
+    this._facetKeys.includes('x') 
+    && this._facetKeys.includes('y')
+    && this._displayTypeForFacet['x']?.type === 'axis'
+    && this._displayTypeForFacet['y']?.type === 'axis'
+    && (this._horizontalAxisFacetKey === null || this._horizontalAxisFacetKey === 'x')
+    && (this._verticalAxisFacetKey === null || this._verticalAxisFacetKey === 'y') ) {
       // NOTE: One (but not both) of these might be rewriting the axis facet key to the same thing
-      this._horizontalAxisFacetKey = independentAxes[0];
-      this._verticalAxisFacetKey = dependentAxes[0];
-    } else if (
-      this._facetKeys.includes('x') 
-      && this._facetKeys.includes('y')
-      && this._displayTypeForFacet['x']?.type === 'axis'
-      && this._displayTypeForFacet['y']?.type === 'axis'
-      && (this._horizontalAxisFacetKey === null || this._horizontalAxisFacetKey === 'x')
-      && (this._verticalAxisFacetKey === null || this._verticalAxisFacetKey === 'y') ) {
-        // NOTE: One (but not both) of these might be rewriting the axis facet key to the same thing
-        this._horizontalAxisFacetKey === 'x';
-        this._verticalAxisFacetKey === 'y';
-    }
-  }*/
+      this._horizontalAxisFacetKey === 'x';
+      this._verticalAxisFacetKey === 'y';
+  }
+}*/
 
 import { Memoize } from 'typescript-memoize';
 
-import { AllSeriesData, CHART_FAMILY_MAP, ChartType, ChartTypeFamily, Dataset, Datatype, DisplayType, 
-  Facet, hasInlineData, Manifest, manifestIsPlaneType, Settings, Topic } from "@fizz/paramanifest";
+import {
+  AllSeriesData, CHART_FAMILY_MAP, ChartType, ChartTypeFamily, Dataset, Datatype, DisplayType,
+  Facet, hasInlineData, Manifest, manifestIsPlaneType, Settings, Topic
+} from "@fizz/paramanifest";
 import type { SeriesAnalysis, SeriesAnalysisOpts, SeriesAnalyzer } from "@fizz/series-analyzer";
 
 import { addArrays, arrayEqualsBy, AxisOrientation, enumerate } from "../utils";
 import { FacetSignature } from "../dataframe/dataframe";
 import { Box, BoxSet } from "../dataframe/box";
-import { AllSeriesStatsScaledValues, calculateFacetStats, FacetStats, generateValues, 
-  SeriesScaledValues } from "../metadata/metadata";
+import {
+  AllSeriesStatsScaledValues, calculateFacetStats, FacetStats, generateValues,
+  SeriesScaledValues
+} from "../metadata/metadata";
 import { Datapoint, PlaneDatapoint } from '../model/datapoint';
 import { PlaneSeries, planeSeriesFromSeriesManifest, Series, seriesFromSeriesManifest } from './series';
 import { Intersection, SeriesPairMetadataAnalyzer, TrackingGroup, TrackingZone } from '../metadata/pair_analyzer_interface';
@@ -150,7 +154,7 @@ export class Model {
         throw new Error('every series in a model must have a unique key');
       }
       if (!arrayEqualsBy(
-        (l, r) => (l.key === r.key) && (l.datatype === r.datatype), 
+        (l, r) => (l.key === r.key) && (l.datatype === r.datatype),
         aSeries.facetSignatures, this.facetSignatures
       )) {
         throw new Error('every series in a model must have the same facets');
@@ -161,8 +165,9 @@ export class Model {
       this._seriesMap[aSeries.key] = aSeries;
       this._seriesLabelMap[aSeries.getLabel()] = aSeries.key;
       this.allPoints.push(...aSeries);
+      const unique = this.type == 'scatter' ? false : true;
       Object.keys(this._uniqueValuesForFacet).forEach((facetKey) => {
-        this._uniqueValuesForFacet[facetKey].merge(aSeries.allFacetValues(facetKey)!);
+        this._uniqueValuesForFacet[facetKey].merge(aSeries.allFacetValues(facetKey)!, unique);
       });
       this._seriesTopicMap[aSeries.key] = aSeries.manifest.topic; // May be undefined
     }
@@ -172,7 +177,7 @@ export class Model {
   public atKey(key: string): Series | null {
     return this._seriesMap[key] ?? null;
   }
-  
+
   public atKeyAndIndex(key: string, index: number): Datapoint | null {
     return this.atKey(key)?.[index] ?? null;
   }
@@ -282,7 +287,7 @@ export class PlaneModel extends Model {
   public readonly convergingGroups: TrackingGroup[] = [];
   public readonly divergingGroups: TrackingGroup[] = [];
   public readonly trackingZones: TrackingZone[] = [];
- 
+
   protected _seriesAnalysisMap?: Record<string, SeriesAnalysis>;
   protected _seriesPairAnalyzer: SeriesPairMetadataAnalyzer | null = null;
   protected _seriesLineMap: Record<string, Line> = {};
@@ -294,7 +299,7 @@ export class PlaneModel extends Model {
   public readonly ys: number[];*/
 
   constructor(
-    series: PlaneSeries[], 
+    series: PlaneSeries[],
     manifest: Manifest,
     private readonly seriesAnalyzerConstructor?: SeriesAnalyzerConstructor,
     private readonly pairAnalyzerConstructor: PairAnalyzerConstructor = BasicSeriesPairMetadataAnalyzer,
@@ -320,19 +325,19 @@ export class PlaneModel extends Model {
       this.verticalAxisKey = this.dependentAxisKey;
     }
 
-    this.grouped = this._dataset.representation.structure?.filter((structure) => 
+    this.grouped = this._dataset.representation.structure?.filter((structure) =>
       structure.role === 'group'
     ).at(0)?.facetKeys.includes(this.dependentAxisKey) ?? false;
 
-    if (this.family === 'line' || this.family === 'bar' || this.family === 'histogram') {
+    if (this.family === 'line' || this.family === 'bar') {
       for (const series of (this.series as PlaneSeries[])) {
         this._seriesLineMap[series.key] = series.getActualLine();
       }
       if (this.multi) {
         const yAxisInterval = this.getAxisInterval(this.getAxisOrientation('dependent'))!;
         this._seriesPairAnalyzer = new this.pairAnalyzerConstructor(
-          Object.values(this._seriesLineMap), 
-          [1,1], //FIXME: get actual screen size
+          Object.values(this._seriesLineMap),
+          [1, 1], //FIXME: get actual screen size
           yAxisInterval.start,
           yAxisInterval.end
         );
@@ -346,7 +351,7 @@ export class PlaneModel extends Model {
         this.trackingZones = this._seriesPairAnalyzer.getTrackingZones();
       }
       // NOTE: `generateValues` must come after `pairAnalyzer` as `generateValues` uses the intersections defined by `pairAnalyzer`
-      [this.seriesScaledValues, this.seriesStatsScaledValues, this.intersectionScaledValues] 
+      [this.seriesScaledValues, this.seriesStatsScaledValues, this.intersectionScaledValues]
         = generateValues(this.series, this.intersections, this.getAxisFacet('vert')?.multiplier as OrderOfMagnitude | undefined);
       for (const key of this.seriesKeys) {
         this._seriesMap[key].scaledValues = this.seriesScaledValues[key];
@@ -431,13 +436,13 @@ export class PlaneModel extends Model {
         start: dependentAxis.start,
         end: Math.max(...summedVals.map(p => p.y))
       };
-      this._summedSeriesAnalysis["sum"] = await seriesAnalyzer.analyzeSeries(
+      this._summedSeriesAnalysis.sum = await seriesAnalyzer.analyzeSeries(
         line, {
         useWorker: this._useWorker,
         yAxis: scaledAxis
       }
       );
-    } 
+    }
     this._seriesAnalysisDone = true;
   }
 
@@ -461,7 +466,7 @@ export class PlaneModel extends Model {
   }
 
   @Memoize()
-  public getAxisOrientation(depIndep: 'dependent'| 'independent'): AxisOrientation {
+  public getAxisOrientation(depIndep: 'dependent' | 'independent'): AxisOrientation {
     const facetKey = depIndep === 'dependent' ? this.dependentAxisKey : this.independentAxisKey;
     if (facetKey === this.verticalAxisKey) {
       return 'vert';
@@ -491,7 +496,7 @@ export class PlaneModel extends Model {
   @Memoize()
   public async getSeriesAnalysis(key: string, options?: SeriesAnalysisOpts): Promise<SeriesAnalysis | null> {
     if (
-      this.type === 'scatter' 
+      ['scatter', 'histogram', 'heatmap'].includes(this.type)
       || !this.seriesAnalyzerConstructor
       || !this.seriesKeys.includes(key)
     ) {
@@ -504,13 +509,13 @@ export class PlaneModel extends Model {
   @Memoize()
   public async getSummedAnalysis(): Promise<SeriesAnalysis | null> {
     if (
-      this.type === 'scatter'
+      ['scatter', 'histogram', 'heatmap'].includes(this.type)
       || !this.seriesAnalyzerConstructor
     ) {
       return null;
     }
     await this.generateSeriesAnalyses();
-    return this._summedSeriesAnalysis["sum"]
+    return this._summedSeriesAnalysis.sum
   }
 
   @Memoize()
@@ -566,7 +571,7 @@ export function modelFromInlineData(manifest: Manifest): Model {
   }
   const dataset = manifest.jim.datasets[0];
   const facets = facetsFromDataset(dataset);
-  const series = dataset.series.map((seriesManifest) => 
+  const series = dataset.series.map((seriesManifest) =>
     seriesFromSeriesManifest(seriesManifest, facets)
   );
   return new Model(series, manifest);
@@ -597,14 +602,14 @@ export function planeModelFromInlineData(
     throw new Error('only manifests with 2D axes can use this function.');
   }
   const facets = facetsFromDataset(dataset);
-  const series = dataset.series.map((seriesManifest) => 
-    planeSeriesFromSeriesManifest(seriesManifest, facets, independentAxisKey, dependentAxisKey)
+  const series = dataset.series.map((seriesManifest) =>
+    planeSeriesFromSeriesManifest(seriesManifest, facets, independentAxisKey, dependentAxisKey, dataset.representation.subtype)
   );
   return new PlaneModel(series, manifest, seriesAnalyzerConstructor, pairAnalyzerConstructor, useWorker);
 }
 
 export function planeModelFromExternalData(
-  data: AllSeriesData, 
+  data: AllSeriesData,
   manifest: Manifest,
   seriesAnalyzerConstructor?: SeriesAnalyzerConstructor,
   pairAnalyzerConstructor?: PairAnalyzerConstructor,
@@ -618,7 +623,7 @@ export function planeModelFromExternalData(
   const facets = facetsFromDataset(dataset);
   const series = Object.keys(data).map((key) => {
     const seriesManifest = dataset.series.filter((s) => s.key === key)[0];
-    return new PlaneSeries(seriesManifest, data[key], facets, independentAxisKey, dependentAxisKey);
+    return new PlaneSeries(seriesManifest, data[key], facets, independentAxisKey, dependentAxisKey, dataset.representation.subtype);
   });
   return new PlaneModel(series, manifest, seriesAnalyzerConstructor, pairAnalyzerConstructor, useWorker);
 }

--- a/lib/model/series.ts
+++ b/lib/model/series.ts
@@ -48,10 +48,11 @@ export class Series {
 
   constructor(
     public readonly manifest: SeriesManifest,
-    public readonly rawData: RawDatapoint[], 
+    public readonly rawData: RawDatapoint[],
     public readonly facetSignatures: FacetSignature[],
     protected readonly indepKey?: string,
-    protected readonly depKey?: string
+    protected readonly depKey?: string,
+    protected type?: string
   ) {
     this.originalKey = this.manifest.key;
     this.key = strToId(this.originalKey);
@@ -66,12 +67,13 @@ export class Series {
     this._dataframe = new DataFrame(facetSignatures);
     this.length = this.rawData.length;
     this.rawData.forEach((datapoint) => this._dataframe.addDatapoint(datapoint));
+    const unique = this.type == 'scatter' ? false : true;
     this._dataframe.rows.forEach((row, index) => {
       const datapoint = this.constructDatapoint(row, this.key, index);
       this[index] = datapoint;
       this.datapoints.push(datapoint);
       Object.keys(row).forEach(
-        (facetKey) => this._uniqueValuesForFacetMappedByKey[facetKey].add(row[facetKey])
+        (facetKey) => this._uniqueValuesForFacetMappedByKey[facetKey].add(row[facetKey], unique)
       );
     });
   }
@@ -159,26 +161,28 @@ export class Series {
 }
 
 export class PlaneSeries extends Series {
-  /*declare*/ [i: number]: PlaneDatapoint;
+  /*declare*/[i: number]: PlaneDatapoint;
 
   declare datapoints: PlaneDatapoint[];
   declare indepKey: string;
   declare depKey: string;
+  declare type: string;
 
   public intersections: Intersection[] = [];
-   
+
   /*protected xMap: Map<ScalarMap[X], number[]>;
   private yMap: Map<number, ScalarMap[X][]>;*/
 
   constructor(
     manifest: SeriesManifest,
-    rawData: RawDatapoint[], 
+    rawData: RawDatapoint[],
     facetSignatures: FacetSignature[],
     indepKey: string,
-    depKey: string
+    depKey: string,
+    type: string
   ) {
-    super(manifest, rawData, facetSignatures, indepKey, depKey);
-
+    super(manifest, rawData, facetSignatures, indepKey, depKey, type);
+    this.type = type;
     console.assert(this.facetKeys.includes(indepKey), `[ParaModel/Internal]: PlaneSeries constructed with unknown indepKey ${indepKey}`);
     console.assert(this.facetKeys.includes(depKey), `[ParaModel/Internal]: PlaneSeries constructed with unknown depKey ${depKey}`);
     console.assert(numberLikeDatatype(this.getFacetDatatype(depKey)), `[ParaModel/Internal]: PlaneSeries depKey ${depKey} has non-number-like ${this.getFacetDatatype(depKey)} datatype`);
@@ -186,7 +190,7 @@ export class PlaneSeries extends Series {
     /*this.xMap = mapDatapointsXtoY(this.datapoints);
     this.yMap = mapDatapointsYtoX(this.datapoints);*/
   }
-  
+
   protected constructDatapoint(data: DataFrameRow, seriesKey: string, datapointIndex: number): Datapoint {
     return new PlaneDatapoint(data, seriesKey, datapointIndex, this.indepKey, this.depKey);
   }
@@ -240,16 +244,17 @@ export function seriesFromSeriesManifest(
 }
 
 export function planeSeriesFromSeriesManifest(
-  seriesManifest: SeriesManifest, facetSignatures: FacetSignature[], indepKey: string, depKey: string
+  seriesManifest: SeriesManifest, facetSignatures: FacetSignature[], indepKey: string, depKey: string, type: string
 ): PlaneSeries {
   if (!seriesManifest.records) {
     throw new Error('only series manifests with inline data can use this method.');
   }
   return new PlaneSeries(
-    seriesManifest, 
-    seriesManifest.records!, 
+    seriesManifest,
+    seriesManifest.records!,
     facetSignatures,
     indepKey,
-    depKey
+    depKey,
+    type
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fizz/breakdancer": "^0.27.6",
         "@fizz/chart-classifier-utils": "^0.17.0",
-        "@fizz/clustering": "^0.16.0",
+        "@fizz/clustering": "^0.18.0",
         "@fizz/number-scaling-rounding": "^0.5.2",
         "@fizz/paramanifest": "^0.11.4",
         "@fizz/templum": "^0.4.6",
@@ -1389,9 +1389,10 @@
       }
     },
     "node_modules/@fizz/clustering": {
-      "version": "0.16.0",
-      "resolved": "https://npm.fizz.studio/@fizz/clustering/-/clustering-0.16.0.tgz",
-      "integrity": "sha512-F8NwB/bmAKtaFs1w0q+bAIpkYjl8UJFZHRGiRt/7MJLT+eTwaD3u37+CbhWyBODxW4KDaVBECuMrT5jZjhnI4Q==",
+      "version": "0.18.0",
+      "resolved": "https://npm.fizz.studio/@fizz/clustering/-/clustering-0.18.0.tgz",
+      "integrity": "sha512-ETjwKNDfMvBjJqVkwjMBpbw5ekDRXPZFcdGv64sm2/aHrzBxqtWHW2JfYIGnr7nBtG/0z0BzrEO+wK8tQBGAqw==",
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
         "polygon-clipping": "^0.15.7",
         "robust-point-in-polygon": "^1.0.3"
@@ -11725,9 +11726,9 @@
       }
     },
     "node_modules/robust-predicates": {
-      "version": "3.0.2",
-      "resolved": "https://npm.fizz.studio/robust-predicates/-/robust-predicates-3.0.2.tgz",
-      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "version": "3.0.3",
+      "resolved": "https://npm.fizz.studio/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
       "license": "Unlicense"
     },
     "node_modules/robust-scale": {
@@ -14323,9 +14324,9 @@
       }
     },
     "@fizz/clustering": {
-      "version": "0.16.0",
-      "resolved": "https://npm.fizz.studio/@fizz/clustering/-/clustering-0.16.0.tgz",
-      "integrity": "sha512-F8NwB/bmAKtaFs1w0q+bAIpkYjl8UJFZHRGiRt/7MJLT+eTwaD3u37+CbhWyBODxW4KDaVBECuMrT5jZjhnI4Q==",
+      "version": "0.18.0",
+      "resolved": "https://npm.fizz.studio/@fizz/clustering/-/clustering-0.18.0.tgz",
+      "integrity": "sha512-ETjwKNDfMvBjJqVkwjMBpbw5ekDRXPZFcdGv64sm2/aHrzBxqtWHW2JfYIGnr7nBtG/0z0BzrEO+wK8tQBGAqw==",
       "requires": {
         "polygon-clipping": "^0.15.7",
         "robust-point-in-polygon": "^1.0.3"
@@ -21299,9 +21300,9 @@
       }
     },
     "robust-predicates": {
-      "version": "3.0.2",
-      "resolved": "https://npm.fizz.studio/robust-predicates/-/robust-predicates-3.0.2.tgz",
-      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
+      "version": "3.0.3",
+      "resolved": "https://npm.fizz.studio/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="
     },
     "robust-scale": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "dependencies": {
     "@fizz/breakdancer": "^0.27.6",
     "@fizz/chart-classifier-utils": "^0.17.0",
-    "@fizz/clustering": "^0.16.0",
+    "@fizz/clustering": "^0.18.0",
     "@fizz/number-scaling-rounding": "^0.5.2",
     "@fizz/paramanifest": "^0.11.4",
     "@fizz/templum": "^0.4.6",


### PR DESCRIPTION
Hotfix that excludes scatterplots from the check to see if `Box` values are unique before adding them to a `BoxSet`. This is an O(n^2) operation, which means roughly 12.5 million equality check operations on a 5000 point scatterplot adding up to around a half second of lag. I checked and none of the downstream functions which rely on this (namely `allFacetValues()`) actually assume that the values in `_uniqueValuesForFacet` are unique for basic numeric scatterplots. This system probably needs a more general overhaul, as it will break when we introduce line charts with irregular date intervals, but this should work for now. 
Note that this does involve the new capability of passing the manifest subtype into the series constructor directly, which is done before the main model is created. I'm not sure if this is something that was consciously avoided for some reason or if there was just no need for it beforehand, but it doesn't appear to break anything.
